### PR TITLE
Add Make API shell connection workflow skill

### DIFF
--- a/skills/make-api-shell-connection-workflow/SKILL.md
+++ b/skills/make-api-shell-connection-workflow/SKILL.md
@@ -54,6 +54,7 @@ Read the file that matches the current task:
 10. For the generic API shell contract that uses `scenario-service:ReturnData` with ExpectDataAny, the final mapper must return the app module response body as `data: {{3.body}}`.
 11. Never replace that shell-contract default with `{{3}}` or `{{3.data}}` just because the full bundle looks tempting. The shell is meant to return the API response body, not the entire Make module bundle.
 12. Still inspect a real execution bundle for validation, but use that to confirm that `body` contains the intended payload or error object — not to redefine the generic shell contract.
+13. If the Module 2 request method is `PUT`, `PATCH`, or `DELETE`, warn explicitly before execution. Treat those methods as mutating live SaaS operations, not passive retrieval.
 
 ## Standard shell shape
 
@@ -154,6 +155,7 @@ When using this skill:
 - when retrieval begins, state the chosen retrieval strategy and why it won over the alternatives
 - explicitly label any assumptions
 - keep write-operation prompts brief and concrete
+- if Module 2 is about to run a `PUT`, `PATCH`, or `DELETE`, stop and warn before execution
 - if activation fails or `ReturnData` looks wrong, stop calling the flow complete and report the exact failing phase
 - if sharing publicly, rewrite examples with placeholders and neutral labels before finalizing
 

--- a/skills/make-api-shell-connection-workflow/SKILL.md
+++ b/skills/make-api-shell-connection-workflow/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: make-api-shell-connection-workflow
-description: Build a reusable Make API-call shell by discovering the correct app-specific Make an API Call module, generating the shell blueprint, and creating or resolving the required connection request. Use when a user wants to connect an app for a generic API shell, create a reusable API-call scenario, find the right Make API-call module, request authorization, or patch the shell with the chosen connection.
+description: Build or reuse a reusable Make API-call shell by discovering the correct app-specific Make an API Call module, resolving or requesting the right connection, running the scenario, and using that shell as the only retrieval transport for email, CRM, tickets, and similar SaaS systems.
 license: MIT
 compatibility: Requires a Make.com account with API access and permissions to create scenarios or credential requests. Works best in environments that can call Make APIs or Make MCP tools.
 metadata:
-  author: Hermes Agent
-  version: "0.2.1"
+  author: Make
+  version: "0.2.4"
   homepage: https://www.make.com
   repository: https://github.com/MAKESEB/make-skills
 ---
@@ -14,11 +14,12 @@ metadata:
 
 Use this skill for one specific workflow family:
 - discover the correct Make app and app-specific API-call module
-- build a reusable shell scenario with StartSubscenario, one app API-call module, and ReturnData
-- create or resolve the connection request needed by that shell
+- reuse or build a reusable shell scenario with StartSubscenario, one app API-call module, and ReturnData
+- reuse an existing suitable connection or create the connection request needed by that shell
 - patch the shell with the selected connection once authorization is complete
+- run the scenario and use it as a generic SaaS retrieval transport for email, CRM, tickets, and similar systems
 
-This skill is primarily about provisioning and shell construction. Treat business retrieval as a second phase that starts only after the connection is ready and the shell or native retrieval path has been validated against current workspace metadata.
+This skill is primarily about provisioning and shell construction. Treat business retrieval as a second phase that starts only after the connection is ready and the shell has been validated against current workspace metadata.
 
 The generic shell described here is an API transport wrapper, not business logic. It should behave like a reusable API endpoint for any SaaS app that Make can front, including email, CRM, ticketing, support, marketing, or task systems.
 
@@ -34,6 +35,37 @@ Read the file that matches the current task:
 | Sanitize examples and prepare a public shareable version | [Sanitization and Sharing](./sanitization-and-sharing.md) |
 | Start from a generic blueprint template | [Example shell blueprint](./examples/generic-api-shell-blueprint.json) |
 
+## Fresh-agent operating sequence
+
+When a fresh agent gets a request such as "get my unread emails", "pull my open CRM leads", or "fetch my Jira tickets", the default operating sequence is:
+
+1. Resolve the provider anchor.
+   - email: Gmail vs Outlook vs other
+   - CRM: HubSpot vs Salesforce vs other
+   - ticketing: Jira vs Zendesk vs Linear vs other
+2. Resolve the target account, mailbox, workspace, project, or queue if the request is ambiguous.
+3. Resolve the active Make zone, organization, and team.
+4. Search the Make app catalog for the provider candidate using `GET /api/v2/imt/apps?organizationId=ORG_ID&teamId=TEAM_ID&scoredSearch=true`.
+5. Inspect the chosen app with `GET /api/v2/imt/apps/{appName}/{version}` and record the exact API-call module slug and both connection type layers.
+6. Reuse an existing suitable connection if one already matches the app, account identity, and required scope.
+7. Reuse an existing shell only when reusing an existing suitable connection. If a new connection must be created, create a new shell for that new connection instead of patching an old shell onto a newly authorized account.
+8. Only if no suitable connection exists, create a credential request.
+9. After the connection decision is settled, create or patch the shell according to the reuse rule above and verify that the shell can run.
+10. Run the narrowest possible retrieval request first through the API-call shell.
+11. Expand into list/search -> detail -> normalization only after the first shell run proves the path works.
+
+The agent should not jump straight from "user wants SaaS data" to "create a new connection" or "call a direct SDK" without walking this sequence.
+
+## Input-resolution gates
+
+Before provisioning or retrieval, explicitly resolve these inputs:
+- provider anchor
+- target account identity if multiple accounts or mailboxes are possible
+- intended credential-request recipient if it may differ from the current token owner
+- Make zone, organization, and team
+
+If one of those items is missing and cannot be discovered safely, stop and ask only for that exact missing item.
+
 ## Core rules
 
 1. Never guess the API-call module name. Discover it from current Make metadata.
@@ -41,20 +73,28 @@ Read the file that matches the current task:
 3. Keep the two type layers separate:
    - scenario/module connection parameter type
    - connection listing or credential request type
-4. Ask for confirmation before writing into an existing live scenario or replacing a connection mapping.
-5. Keep public examples sanitized. Do not include real names, user IDs, team IDs, organization IDs, tenant-specific hosts, or claims that a single private workspace proves a universal rule.
-6. Use a clean base URL variable in examples. For public examples, prefer `https://us1.make.com` and do not mention `we.make.com`. Keep placeholders generic unless the current user explicitly provides the Make zone.
-7. Separate four phases explicitly:
+4. Prefer reuse before creation:
+   - existing suitable connection before new credential request
+   - existing shell scenario only when reusing an existing suitable connection
+   - a newly authorized connection must get a newly created shell
+5. Do not route business retrieval to native Make search/list/get modules. For this workflow family, always retrieve through the Make app's API-call shell.
+6. Ask for confirmation before writing into an existing live scenario or replacing a connection mapping.
+7. Keep public examples sanitized. Do not include real names, user IDs, team IDs, organization IDs, tenant-specific hosts, or claims that a single private workspace proves a universal rule.
+8. Use a clean base URL variable in examples. For public examples, prefer `https://us1.make.com` and do not mention `we.make.com`. Keep placeholders generic unless the current user explicitly provides the Make zone. Zones can be eu1, eu2, us1, us2 or we. If the user wants to give a custom zone or BaseURL accept it. 
+9. Separate four phases explicitly:
+   - provider and app resolution
    - connection provisioning
    - shell provisioning
-   - retrieval execution
-   - output normalization
-8. Do not assume the generic three-module blueprint is automatically activatable for every app. Before activation, compare the middle module metadata with a real current blueprint or module export for the same app and version in the active workspace.
-9. Prefer provider-native search/list/get modules for business retrieval when they match the user request. Use the generic API-call shell when native retrieval modules are missing, insufficient, or the endpoint must stay open-ended.
-10. For the generic API shell contract that uses `scenario-service:ReturnData` with ExpectDataAny, the final mapper must return the app module response body as `data: {{3.body}}`.
-11. Never replace that shell-contract default with `{{3}}` or `{{3.data}}` just because the full bundle looks tempting. The shell is meant to return the API response body, not the entire Make module bundle.
-12. Still inspect a real execution bundle for validation, but use that to confirm that `body` contains the intended payload or error object — not to redefine the generic shell contract.
-13. If the Module 2 request method is `PUT`, `PATCH`, or `DELETE`, warn explicitly before execution. Treat those methods as mutating live SaaS operations, not passive retrieval.
+   - retrieval execution and output normalization
+10. Do not assume the generic three-module blueprint is automatically activatable for every app. Before activation, compare the middle module metadata with a real current blueprint or module export for the same app and version in the active workspace.
+11. For the generic API shell contract that uses `scenario-service:ReturnData` with ExpectDataAny, the final mapper must return the app module response body as `data: {{3.body}}`.
+12. Never replace that shell-contract default with `{{3}}` or `{{3.data}}` just because the full bundle looks tempting. The shell is meant to return the API response body, not the entire Make module bundle.
+13. Still inspect a real execution bundle for validation, but use that to confirm that `body` contains the intended payload or error object — not to redefine the generic shell contract.
+14. Resolve the active workspace zone before any team-scoped call. `GET /api/v2/users/me` and `GET /api/v2/imt/apps/...` can succeed on multiple zones, while `GET /api/v2/connections?teamId=...` or scenario endpoints on the wrong zone can fail with `403 Permission denied`.
+15. For the REST `/api/v2/connections` endpoint, filter with `type=...` or `type[]=...`. Do not assume query parameters such as `accountName=...` are honored just because an MCP tool uses `accountName` terminology.
+16. Do not ask the user to paste raw OAuth secrets, API keys, or passwords into chat. Use a credential request whenever a new connection must be created.
+17. If the user request is ambiguous, resolve the concrete provider and account first; if it is already explicit, do not ask again.
+18. If the Module 2 request method is `PUT`, `PATCH`, or `DELETE`, warn explicitly before execution. Treat those methods as mutating live SaaS operations, not passive retrieval.
 
 ## Standard shell shape
 
@@ -83,6 +123,8 @@ It receives:
 
 It forwards those values into the app-specific Make API-call module.
 
+Default retrieval should use `GET`. Treat `PUT`, `PATCH`, and `DELETE` as write/destructive methods and require explicit user confirmation before running them.
+
 It returns exactly one thing:
 - the response body from the app-specific Make API-call module
 
@@ -110,49 +152,42 @@ Complete these steps first:
 1. identify the provider and exact Make app
 2. discover the exact app version and module slug
 3. determine both connection type layers
-4. create or patch the shell scenario
-5. create or resolve the credential request
-6. patch in the authorized connection
+4. look for an existing suitable connection for the correct account identity and scope
+5. look for an existing shell scenario that already fits the contract for that existing connection
+6. create or resolve the credential request only if reuse failed
+7. create a new shell if a new connection was created, or patch an existing shell only when reusing an existing connection
+8. verify that the shell runs with the chosen connection
 
 Deliverable at the end of Phase A:
-- a connection-ready scenario or a connection-ready native retrieval module plan
+- a connection-ready API-call shell scenario
 
 ### Phase B: retrieval
 Only after Phase A succeeds:
-1. choose the retrieval strategy
+1. configure the retrieval call through the API-call shell
 2. run a narrow validation query or lookup
 3. inspect the real output bundle shape
-4. update `ReturnData` or downstream normalization based on the observed shape
+4. keep `ReturnData` fixed as the generic shell contract and update only downstream normalization if needed
 5. rerun and verify the user-facing payload
 
 Do not treat a successful credential request as proof that the retrieval stage is already solved.
 
 Important:
-- if you are still using the generic three-module API shell, keep the shell contract fixed as `data: {{3.body}}`
-- choose other mappings only when you are no longer describing the generic shell contract, but a retrieval-specific scenario or downstream normalization layer
-
-## Retrieval strategy ladder
-
-Prefer this order unless current metadata shows otherwise:
-1. provider-native search/list/get modules for business retrieval
-2. provider-native detail/get-by-id modules for follow-up enrichment
-3. generic API-call shell for unsupported or custom endpoints
-
-Examples of provider-native retrieval families include:
-- email providers: search/list messages, then get message detail if needed
-- CRM providers: search/list records, then get record detail
-- issue trackers: search/list issues, then get issue detail
-
-Use the generic API-call shell when the user truly needs arbitrary endpoint access or when native modules cannot express the needed operation cleanly.
-
-That does not change the generic shell contract itself. The shell still returns `{{3.body}}`; only the later interpretation of that body changes.
+- the generic three-module API shell remains the only retrieval transport in this workflow family
+- keep the shell contract fixed as `data: {{3.body}}`
+- do not switch to native retrieval/search/list modules as a fallback or optimization
+- if authorization fails because an existing connection is expired or invalid, do not try to re-auth that connection in place; go through the credential-request path and then create a new shell for the new connection
 
 ## Response behavior
 
 When using this skill:
 - first summarize the discovered app, version, exact API-call module name, and both connection type layers
+- explicitly state how the provider was resolved: user statement, existing Make artifacts, or Make app-catalog lookup
+- explicitly say whether the shell is being reused or newly created
+- explicitly say whether the connection is being reused or newly requested
 - explicitly state which phase you are in: provisioning or retrieval
-- when retrieval begins, state the chosen retrieval strategy and why it won over the alternatives
+- when retrieval begins, state the API-call plan: list/search path, any follow-up detail paths, and normalization plan
+- if a new connection was created, explicitly state that a new shell was created for it
+- if the request started as a business ask such as email, CRM, or tickets, state the business target and the exact API path pattern you chose
 - explicitly label any assumptions
 - keep write-operation prompts brief and concrete
 - if Module 2 is about to run a `PUT`, `PATCH`, or `DELETE`, stop and warn before execution

--- a/skills/make-api-shell-connection-workflow/SKILL.md
+++ b/skills/make-api-shell-connection-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires a Make.com account with API access and permissions to create scenarios or credential requests. Works best in environments that can call Make APIs or Make MCP tools.
 metadata:
   author: Hermes Agent
-  version: "0.1.0"
+  version: "0.2.0"
   homepage: https://www.make.com
   repository: https://github.com/integromat/make-skills
 ---
@@ -18,6 +18,8 @@ Use this skill for one specific workflow family:
 - create or resolve the connection request needed by that shell
 - patch the shell with the selected connection once authorization is complete
 
+This skill is primarily about provisioning and shell construction. Treat business retrieval as a second phase that starts only after the connection is ready and the shell or native retrieval path has been validated against current workspace metadata.
+
 ## Quick routing
 
 Read the file that matches the current task:
@@ -26,6 +28,7 @@ Read the file that matches the current task:
 |------|-----------|
 | Discover the app, module, and connection type layers | [Discovery and Shells](./discovery-and-shells.md) |
 | Create, inspect, or resolve a credential request | [Connection Requests](./connection-requests.md) |
+| Choose and execute the post-connection retrieval path | [Retrieval Execution](./retrieval-execution.md) |
 | Sanitize examples and prepare a public shareable version | [Sanitization and Sharing](./sanitization-and-sharing.md) |
 | Start from a generic blueprint template | [Example shell blueprint](./examples/generic-api-shell-blueprint.json) |
 
@@ -38,7 +41,15 @@ Read the file that matches the current task:
    - connection listing or credential request type
 4. Ask for confirmation before writing into an existing live scenario or replacing a connection mapping.
 5. Keep public examples sanitized. Do not include real names, user IDs, team IDs, organization IDs, tenant-specific hosts, or claims that a single private workspace proves a universal rule.
-6. Use a clean base URL variable in examples. Keep placeholders generic unless the current user explicitly provides the Make zone.
+6. Use a clean base URL variable in examples. For public examples, prefer `https://us1.make.com` and do not mention `we.make.com`. Keep placeholders generic unless the current user explicitly provides the Make zone.
+7. Separate four phases explicitly:
+   - connection provisioning
+   - shell provisioning
+   - retrieval execution
+   - output normalization
+8. Do not assume the generic three-module blueprint is automatically activatable for every app. Before activation, compare the middle module metadata with a real current blueprint or module export for the same app and version in the active workspace.
+9. Prefer provider-native search/list/get modules for business retrieval when they match the user request. Use the generic API-call shell when native retrieval modules are missing, insufficient, or the endpoint must stay open-ended.
+10. Never lock in a `ReturnData` mapper until at least one real execution bundle from the chosen retrieval module has been inspected.
 
 ## Standard shell shape
 
@@ -55,12 +66,53 @@ Expose these shell inputs through StartSubscenario:
 
 Use the discovered middle module as the only app-specific part of the shell.
 
+## Two-phase operating model
+
+### Phase A: provisioning
+Complete these steps first:
+1. identify the provider and exact Make app
+2. discover the exact app version and module slug
+3. determine both connection type layers
+4. create or patch the shell scenario
+5. create or resolve the credential request
+6. patch in the authorized connection
+
+Deliverable at the end of Phase A:
+- a connection-ready scenario or a connection-ready native retrieval module plan
+
+### Phase B: retrieval
+Only after Phase A succeeds:
+1. choose the retrieval strategy
+2. run a narrow validation query or lookup
+3. inspect the real output bundle shape
+4. update `ReturnData` or downstream normalization based on the observed shape
+5. rerun and verify the user-facing payload
+
+Do not treat a successful credential request as proof that the retrieval stage is already solved.
+
+## Retrieval strategy ladder
+
+Prefer this order unless current metadata shows otherwise:
+1. provider-native search/list/get modules for business retrieval
+2. provider-native detail/get-by-id modules for follow-up enrichment
+3. generic API-call shell for unsupported or custom endpoints
+
+Examples of provider-native retrieval families include:
+- email providers: search/list messages, then get message detail if needed
+- CRM providers: search/list records, then get record detail
+- issue trackers: search/list issues, then get issue detail
+
+Use the generic API-call shell when the user truly needs arbitrary endpoint access or when native modules cannot express the needed operation cleanly.
+
 ## Response behavior
 
 When using this skill:
 - first summarize the discovered app, version, exact API-call module name, and both connection type layers
+- explicitly state which phase is active: provisioning or retrieval
+- when retrieval begins, state the chosen retrieval strategy and why it won over the alternatives
 - explicitly label any assumptions
 - keep write-operation prompts brief and concrete
+- if activation fails or `ReturnData` looks wrong, stop calling the flow complete and report the exact failing phase
 - if sharing publicly, rewrite examples with placeholders and neutral labels before finalizing
 
 ## Related skills

--- a/skills/make-api-shell-connection-workflow/SKILL.md
+++ b/skills/make-api-shell-connection-workflow/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: make-api-shell-connection-workflow
-description: Build or reuse a reusable Make API-call shell by discovering the correct app-specific Make an API Call module, resolving or requesting the right connection, running the scenario, and using that shell as the only retrieval transport for email, CRM, tickets, and similar SaaS systems.
+description: Build or reuse a reusable Make API-call shell by discovering the correct app-specific Make an API Call module, resolving or requesting the right connection, explicitly setting the scenario interface, running the scenario, and using that shell as the retrieval transport for email, CRM, tickets, and similar SaaS systems.
 license: MIT
 compatibility: Requires a Make.com account with API access and permissions to create scenarios or credential requests. Works best in environments that can call Make APIs or Make MCP tools.
 metadata:
   author: Make
-  version: "0.2.4"
+  version: "0.3.0"
   homepage: https://www.make.com
   repository: https://github.com/MAKESEB/make-skills
 ---
@@ -80,7 +80,7 @@ If one of those items is missing and cannot be discovered safely, stop and ask o
 5. Do not route business retrieval to native Make search/list/get modules. For this workflow family, always retrieve through the Make app's API-call shell.
 6. Ask for confirmation before writing into an existing live scenario or replacing a connection mapping.
 7. Keep public examples sanitized. Do not include real names, user IDs, team IDs, organization IDs, tenant-specific hosts, or claims that a single private workspace proves a universal rule.
-8. Use a clean base URL variable in examples. For public examples, prefer `https://us1.make.com` and do not mention `we.make.com`. Keep placeholders generic unless the current user explicitly provides the Make zone. Zones can be eu1, eu2, us1, us2 or we. If the user wants to give a custom zone or BaseURL accept it. 
+8. Use a clean base URL variable in examples. For public examples, prefer `https://us1.make.com` and do not mention `we.make.com`. Keep placeholders generic unless the current user explicitly provides the Make zone. Zones can be `eu1`, `eu2`, `us1`, `us2`, or `we`. If the user wants to give a custom zone or `BASE_URL`, accept it.
 9. Separate four phases explicitly:
    - provider and app resolution
    - connection provisioning
@@ -95,6 +95,30 @@ If one of those items is missing and cannot be discovered safely, stop and ask o
 16. Do not ask the user to paste raw OAuth secrets, API keys, or passwords into chat. Use a credential request whenever a new connection must be created.
 17. If the user request is ambiguous, resolve the concrete provider and account first; if it is already explicit, do not ask again.
 18. If the Module 2 request method is `PUT`, `PATCH`, or `DELETE`, warn explicitly before execution. Treat those methods as mutating live SaaS operations, not passive retrieval.
+19. Do not assume `StartSubscenario.metadata.interface` is enough for scenario runs. After creating or updating an on-demand shell, explicitly set the scenario-level interface with `/api/v2/scenarios/{scenarioId}/interface` and verify it before the first run.
+20. Treat `/api/v2/scenarios/{scenarioId}/run` as the standard execution path for this shell family. Pass the business payload under `data` with keys that match the scenario interface exactly, and prefer `responsive: true` for validation runs.
+21. Shell reuse is app-specific, not just provider-family-specific. A shell built around one app module should not be repointed to another app module just because both belong to the same vendor suite.
+
+## App binding and connection-family matrix
+
+The shell pattern is generic, but each actual shell is bound to one discovered Make app module.
+
+Do not treat “Google” or “Microsoft” as a single interchangeable connection family. In Make, app families often split by product surface.
+
+Common examples:
+
+| Business surface | Example API-call module | Scenario/module connection parameter type | Common connection listing or request type |
+|---|---|---|---|
+| Gmail | `google-email:makeAnApiCall` | `account:google-email` | `google-email` or workspace-specific variants such as `google-restricted` |
+| Google Calendar / Sheets / Drive style apps | app-specific Google module discovered from metadata | commonly `account:google` | commonly `google` |
+| Outlook / Microsoft mail | `microsoft-email:makeApiCall` | `account:azure` | `azure` |
+
+Rules that follow from this:
+- Reuse a shell only when the discovered app, module slug, version, and connection family still match.
+- Reuse a connection only when the account identity and scopes still fit the requested operation.
+- If a new connection is authorized for a different account or connection family, create a new shell for it instead of silently repointing an old shell.
+
+When in doubt, inspect the exact app metadata and existing connection detail instead of inferring compatibility from the vendor name.
 
 ## Standard shell shape
 
@@ -176,6 +200,45 @@ Important:
 - keep the shell contract fixed as `data: {{3.body}}`
 - do not switch to native retrieval/search/list modules as a fallback or optimization
 - if authorization fails because an existing connection is expired or invalid, do not try to re-auth that connection in place; go through the credential-request path and then create a new shell for the new connection
+
+### Interface-and-run rule
+
+For on-demand shells, treat interface provisioning as a separate deployment step:
+1. create or update the scenario blueprint
+2. explicitly set `/api/v2/scenarios/{scenarioId}/interface`
+3. verify the interface shape before the first run
+4. only then call `/api/v2/scenarios/{scenarioId}/run`
+
+Use a run payload shaped like:
+
+```json
+{
+  "data": {
+    "path": "...",
+    "method": "GET",
+    "header": [],
+    "body": null
+  },
+  "responsive": true
+}
+```
+
+The key names under `data` must match the scenario interface exactly. If the interface was never explicitly set, `run` can reject the call even when the `StartSubscenario` module itself contains interface metadata.
+
+### Body-handling compatibility rule
+
+Keep the generic shell contract stable, but do not assume every provider module tolerates an empty or null body the same way.
+
+Observed-safe pattern:
+- write-capable shells can expose and map `body`
+- read-heavy shells may need to omit the Module 2 `body` mapper entirely when the provider module serializes empty payloads badly on `GET` or `DELETE`
+
+If a provider-specific Make API-call module fails only when `body` is present-but-empty, prefer one of these patterns:
+- a read shell without a `body` mapper
+- a write shell with a `body` mapper
+- two separate shells when the provider behavior differs between read and write paths
+
+Do not change `ReturnData` for this. This is a Module 2 request-shape compatibility issue, not a shell-output-contract issue.
 
 ## Response behavior
 

--- a/skills/make-api-shell-connection-workflow/SKILL.md
+++ b/skills/make-api-shell-connection-workflow/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: make-api-shell-connection-workflow
+description: Build a reusable Make API-call shell by discovering the correct app-specific Make an API Call module, generating the shell blueprint, and creating or resolving the required connection request. Use when a user wants to connect an app for a generic API shell, create a reusable API-call scenario, find the right Make API-call module, request authorization, or patch the shell with the chosen connection.
+license: MIT
+compatibility: Requires a Make.com account with API access and permissions to create scenarios or credential requests. Works best in environments that can call Make APIs or Make MCP tools.
+metadata:
+  author: Hermes Agent
+  version: "0.1.0"
+  homepage: https://www.make.com
+  repository: https://github.com/integromat/make-skills
+---
+
+# Make API Shell + Connection Workflow
+
+Use this skill for one specific workflow family:
+- discover the correct Make app and app-specific API-call module
+- build a reusable shell scenario with StartSubscenario, one app API-call module, and ReturnData
+- create or resolve the connection request needed by that shell
+- patch the shell with the selected connection once authorization is complete
+
+## Quick routing
+
+Read the file that matches the current task:
+
+| Task | Reference |
+|------|-----------|
+| Discover the app, module, and connection type layers | [Discovery and Shells](./discovery-and-shells.md) |
+| Create, inspect, or resolve a credential request | [Connection Requests](./connection-requests.md) |
+| Sanitize examples and prepare a public shareable version | [Sanitization and Sharing](./sanitization-and-sharing.md) |
+| Start from a generic blueprint template | [Example shell blueprint](./examples/generic-api-shell-blueprint.json) |
+
+## Core rules
+
+1. Never guess the API-call module name. Discover it from current Make metadata.
+2. Treat example apps such as Gmail, Outlook, or HubSpot as illustrations, not as universal defaults.
+3. Keep the two type layers separate:
+   - scenario/module connection parameter type
+   - connection listing or credential request type
+4. Ask for confirmation before writing into an existing live scenario or replacing a connection mapping.
+5. Keep public examples sanitized. Do not include real names, user IDs, team IDs, organization IDs, tenant-specific hosts, or claims that a single private workspace proves a universal rule.
+6. Use a clean base URL variable in examples. Keep placeholders generic unless the current user explicitly provides the Make zone.
+
+## Standard shell shape
+
+The reusable shell has exactly three modules:
+1. `scenario-service:StartSubscenario`
+2. one app-specific Make API-call module discovered from metadata
+3. `scenario-service:ReturnData`
+
+Expose these shell inputs through StartSubscenario:
+- `path`
+- `method`
+- `header`
+- `body`
+
+Use the discovered middle module as the only app-specific part of the shell.
+
+## Response behavior
+
+When using this skill:
+- first summarize the discovered app, version, exact API-call module name, and both connection type layers
+- explicitly label any assumptions
+- keep write-operation prompts brief and concrete
+- if sharing publicly, rewrite examples with placeholders and neutral labels before finalizing
+
+## Related skills
+
+- `make-scenario-building` for broader scenario architecture beyond this shell pattern
+- `make-module-configuring` for detailed module configuration, mapping, webhooks, keys, and data stores
+- `make-mcp-reference` for Make MCP connection methods, scopes, and timeout behavior

--- a/skills/make-api-shell-connection-workflow/SKILL.md
+++ b/skills/make-api-shell-connection-workflow/SKILL.md
@@ -5,9 +5,9 @@ license: MIT
 compatibility: Requires a Make.com account with API access and permissions to create scenarios or credential requests. Works best in environments that can call Make APIs or Make MCP tools.
 metadata:
   author: Hermes Agent
-  version: "0.2.0"
+  version: "0.2.1"
   homepage: https://www.make.com
-  repository: https://github.com/integromat/make-skills
+  repository: https://github.com/MAKESEB/make-skills
 ---
 
 # Make API Shell + Connection Workflow
@@ -19,6 +19,8 @@ Use this skill for one specific workflow family:
 - patch the shell with the selected connection once authorization is complete
 
 This skill is primarily about provisioning and shell construction. Treat business retrieval as a second phase that starts only after the connection is ready and the shell or native retrieval path has been validated against current workspace metadata.
+
+The generic shell described here is an API transport wrapper, not business logic. It should behave like a reusable API endpoint for any SaaS app that Make can front, including email, CRM, ticketing, support, marketing, or task systems.
 
 ## Quick routing
 
@@ -49,7 +51,9 @@ Read the file that matches the current task:
    - output normalization
 8. Do not assume the generic three-module blueprint is automatically activatable for every app. Before activation, compare the middle module metadata with a real current blueprint or module export for the same app and version in the active workspace.
 9. Prefer provider-native search/list/get modules for business retrieval when they match the user request. Use the generic API-call shell when native retrieval modules are missing, insufficient, or the endpoint must stay open-ended.
-10. Never lock in a `ReturnData` mapper until at least one real execution bundle from the chosen retrieval module has been inspected.
+10. For the generic API shell contract that uses `scenario-service:ReturnData` with ExpectDataAny, the final mapper must return the app module response body as `data: {{3.body}}`.
+11. Never replace that shell-contract default with `{{3}}` or `{{3.data}}` just because the full bundle looks tempting. The shell is meant to return the API response body, not the entire Make module bundle.
+12. Still inspect a real execution bundle for validation, but use that to confirm that `body` contains the intended payload or error object — not to redefine the generic shell contract.
 
 ## Standard shell shape
 
@@ -65,6 +69,38 @@ Expose these shell inputs through StartSubscenario:
 - `body`
 
 Use the discovered middle module as the only app-specific part of the shell.
+
+## Generic shell contract
+
+This shell is a generic API endpoint wrapper.
+
+It receives:
+- `path`
+- `method`
+- `header`
+- `body`
+
+It forwards those values into the app-specific Make API-call module.
+
+It returns exactly one thing:
+- the response body from the app-specific Make API-call module
+
+Therefore the shell contract is:
+
+```json
+{
+  "data": "{{3.body}}"
+}
+```
+
+That contract is generic across SaaS providers. It applies whether the middle module fronts Gmail, Outlook, HubSpot, Jira, or another provider-specific Make API-call module.
+
+The shell should not try to return:
+- the whole Make bundle `{{3}}`
+- a guessed nested field such as `{{3.data}}`
+- transport metadata mixed together with the body
+
+The shell is transport only. Business interpretation happens later.
 
 ## Two-phase operating model
 
@@ -90,6 +126,10 @@ Only after Phase A succeeds:
 
 Do not treat a successful credential request as proof that the retrieval stage is already solved.
 
+Important:
+- if you are still using the generic three-module API shell, keep the shell contract fixed as `data: {{3.body}}`
+- choose other mappings only when you are no longer describing the generic shell contract, but a retrieval-specific scenario or downstream normalization layer
+
 ## Retrieval strategy ladder
 
 Prefer this order unless current metadata shows otherwise:
@@ -104,11 +144,13 @@ Examples of provider-native retrieval families include:
 
 Use the generic API-call shell when the user truly needs arbitrary endpoint access or when native modules cannot express the needed operation cleanly.
 
+That does not change the generic shell contract itself. The shell still returns `{{3.body}}`; only the later interpretation of that body changes.
+
 ## Response behavior
 
 When using this skill:
 - first summarize the discovered app, version, exact API-call module name, and both connection type layers
-- explicitly state which phase is active: provisioning or retrieval
+- explicitly state which phase you are in: provisioning or retrieval
 - when retrieval begins, state the chosen retrieval strategy and why it won over the alternatives
 - explicitly label any assumptions
 - keep write-operation prompts brief and concrete

--- a/skills/make-api-shell-connection-workflow/connection-requests.md
+++ b/skills/make-api-shell-connection-workflow/connection-requests.md
@@ -19,6 +19,11 @@ Prefer the most current supported path first, then fall back only when needed.
    - `POST /api/v2/credential-requests/actions/create-by-credentials`
 3. Use older legacy request paths only when the workspace clearly still depends on them.
 
+Important branching rule:
+- if the workspace returns a policy or permission denial such as `403 Permission denied` or a message indicating credential requests are not enabled for the target user/workspace, stop and report a workspace feature restriction
+- do not keep retrying equivalent credential-request endpoints when the failure is clearly policy-based rather than endpoint-shape-based
+- only fall back to another endpoint when the evidence suggests API-version mismatch, route availability, or request-shape incompatibility
+
 ## Recommended V2 request style
 
 Why this is preferable:
@@ -74,6 +79,8 @@ Confirm:
 - credential state
 - resulting credential or connection identifier
 
+Also confirm whether the resulting connection is usable in the target scenario or module family. Authorization success alone does not prove that retrieval execution is correctly configured.
+
 ## Patch the scenario after authorization
 
 Once the chosen connection exists:
@@ -91,6 +98,11 @@ Always record these values first:
 - exact connection field or restore path to update
 - selected connection ID
 - both connection type layers for the app
+
+If the request was created for a different recipient than the current token owner, also record:
+- intended recipient identity
+- recipient Make user ID if known
+- any workspace or feature limitations discovered during request creation
 
 ## Safe user-facing write prompt
 

--- a/skills/make-api-shell-connection-workflow/connection-requests.md
+++ b/skills/make-api-shell-connection-workflow/connection-requests.md
@@ -46,6 +46,14 @@ curl -sS \
 
 For REST calls, prefer the `type` filter. Do not rely on `accountName=...` query parameters to filter the response.
 
+Do not treat a type match alone as enough to reuse the connection. Also confirm:
+- the connection family matches the discovered module's expected connection family
+- the account identity matches the requested mailbox, tenant, workspace, or user
+- the scope set is sufficient for the intended API path and method
+- the connection is not known to be expired, revoked, or otherwise invalid
+
+If Make MCP or another supported surface exposes connection detail, inspect it before reuse. Useful checks include the visible account label and scope count.
+
 ## Recipient and account-identity gate
 
 Before creating a new credential request, resolve two separate questions:
@@ -76,6 +84,8 @@ Reason:
 - it avoids silently repointing an existing reusable scenario from one account to another
 - it generalizes across email, CRM, ticketing, and other SaaS providers
 
+It also prevents a different class of mismatch: same vendor suite, wrong connection family. Example: a provider's mail app and calendar app may both authenticate through the same vendor, while the discovered Make modules still require different app bindings or different connection families.
+
 ## Recommended V2 request style
 
 Why this is preferable:
@@ -100,6 +110,8 @@ Example body with placeholders:
 }
 ```
 
+Use this path when the workspace can infer the needed connection family from the discovered app/module context and you do not need to force an explicit connection type.
+
 ## Fallback create-by-credentials style
 
 Use this when the workspace requires an explicit connection type.
@@ -120,6 +132,13 @@ Example body with placeholders:
   ]
 }
 ```
+
+This fallback is often the safer generic choice when you already know the exact connection family and scope requirement and want the request to encode them directly.
+
+Practical rule:
+- prefer the V2 request style first
+- if the workspace does not infer the right connection family, or if the request needs an explicit scope declaration, fall back to `create-by-credentials`
+- for Google-family apps in particular, verify whether the discovered module expects a Gmail-specific family such as `google-email` or a broader Google family such as `google`
 
 ## Inspect authorization state
 

--- a/skills/make-api-shell-connection-workflow/connection-requests.md
+++ b/skills/make-api-shell-connection-workflow/connection-requests.md
@@ -1,0 +1,112 @@
+# Connection Requests
+
+This file covers how to request authorization for the shell, inspect the result, and patch the selected connection into the scenario.
+
+## Authentication format
+
+Use a Make API token in the header:
+```text
+Authorization: Token YOUR_API_KEY
+```
+
+## Decision ladder
+
+Prefer the most current supported path first, then fall back only when needed.
+
+1. Try:
+   - `POST /api/v2/credential-requests/requests/v2`
+2. If that path is unavailable for the workspace or feature set, try:
+   - `POST /api/v2/credential-requests/actions/create-by-credentials`
+3. Use older legacy request paths only when the workspace clearly still depends on them.
+
+## Recommended V2 request style
+
+Why this is preferable:
+- you specify the app and module context directly
+- Make can derive required credential types more reliably
+- the request is less dependent on hardcoded connection-type assumptions
+
+Example body with placeholders:
+```json
+{
+  "name": "Outlook API shell connection",
+  "teamId": TEAM_ID,
+  "description": "Authorize Outlook for the generic API shell scenario.",
+  "credentials": [
+    {
+      "appName": "microsoft-email",
+      "appModules": ["makeApiCall"],
+      "appVersion": 2,
+      "nameOverride": "outlook-api-shell"
+    }
+  ]
+}
+```
+
+## Fallback create-by-credentials style
+
+Use this when the workspace requires an explicit connection type.
+
+Example body with placeholders:
+```json
+{
+  "name": "Gmail API shell connection",
+  "description": "Authorize Gmail for the generic API shell scenario.",
+  "teamId": TEAM_ID,
+  "connections": [
+    {
+      "type": "google-email",
+      "description": "Readonly Gmail connection for the API shell example.",
+      "scope": ["https://www.googleapis.com/auth/gmail.readonly"],
+      "nameOverride": "gmail-api-shell"
+    }
+  ]
+}
+```
+
+## Inspect authorization state
+
+After the user opens the public authorization URL and completes consent, inspect the request:
+- `GET /api/v2/credential-requests/requests/{requestId}/detail`
+
+Confirm:
+- request status
+- credential state
+- resulting credential or connection identifier
+
+## Patch the scenario after authorization
+
+Once the chosen connection exists:
+1. inspect the current blueprint
+2. inject the confirmed connection value in the correct module field or restore structure
+3. update the scenario
+4. activate it if needed
+5. run a verification execution
+
+## What to record before patching
+
+Always record these values first:
+- scenario ID
+- target module ID in the blueprint
+- exact connection field or restore path to update
+- selected connection ID
+- both connection type layers for the app
+
+## Safe user-facing write prompt
+
+Use a brief confirmation prompt before patching an existing scenario:
+
+```text
+You asked me to patch the Make shell with the authorized connection.
+Risk: this can overwrite the current connection mapping and stop the scenario if the wrong connection is inserted.
+Example: if the shell expects an Outlook connection and I patch a different credential, the API-call module can fail until corrected.
+Reply with YES to proceed, or tell me what to change first.
+```
+
+## Public sharing rule
+
+If this workflow is being published or contributed to a shared repository:
+- replace real team IDs, organization IDs, user IDs, connection IDs, and workspace-specific names with placeholders
+- use neutral labels such as `gmail-api-shell` instead of personal labels
+- avoid phrases such as `verified live` or `worked in tenant X`
+- describe fallbacks as compatibility options, not as tenant-specific facts

--- a/skills/make-api-shell-connection-workflow/connection-requests.md
+++ b/skills/make-api-shell-connection-workflow/connection-requests.md
@@ -13,6 +13,7 @@ Authorization: Token YOUR_API_KEY
 
 Prefer the most current supported path first, then fall back only when needed.
 
+0. Before creating anything, list existing connections for the target app in the active team and reuse one if it already satisfies the workflow.
 1. Try:
    - `POST /api/v2/credential-requests/requests/v2`
 2. If that path is unavailable for the workspace or feature set, try:
@@ -23,6 +24,57 @@ Important branching rule:
 - if the workspace returns a policy or permission denial such as `403 Permission denied` or a message indicating credential requests are not enabled for the target user/workspace, stop and report a workspace feature restriction
 - do not keep retrying equivalent credential-request endpoints when the failure is clearly policy-based rather than endpoint-shape-based
 - only fall back to another endpoint when the evidence suggests API-version mismatch, route availability, or request-shape incompatibility
+- if authorization fails because an existing connection is expired, revoked, or otherwise invalid, do not try to re-auth that connection in place; use the credential-request path to create a fresh connection
+
+## Preflight: reuse before create
+
+Before opening a new credential request, verify all of the following:
+- correct zone
+- correct organization and team
+- the provider has already been proven in the Make app catalog for this organization/team
+- existing connections for the target app in that team
+- whether one of those connections is already suitable for the requested account and scope
+
+REST example:
+```bash
+curl -sS \
+  -H "authorization: Token $API_KEY" \
+  -H 'accept: application/json' \
+  -H 'user-agent: Mozilla/5.0' \
+  "${BASE_URL}/api/v2/connections?teamId=${TEAM_ID}&type[]=azure"
+```
+
+For REST calls, prefer the `type` filter. Do not rely on `accountName=...` query parameters to filter the response.
+
+## Recipient and account-identity gate
+
+Before creating a new credential request, resolve two separate questions:
+
+1. Who should complete the authorization flow?
+2. Which provider account should the resulting connection point at?
+
+Do not assume the current Make token owner is automatically the right credential-request recipient if the task is for another human or shared account.
+
+Do not assume the first matching connection is correct when multiple connections exist for the same app. Compare at least:
+- connection type
+- account metadata such as email, domain, tenant, or UID when available
+- scenario usage if the shell is expected to reuse a known existing scenario
+- scope fit for the requested operation
+
+If the intended recipient or target account identity is unclear, stop and ask for that exact missing item before creating a new request.
+
+## New-connection rule
+
+If a new credential request results in a newly authorized connection, create a new shell for that new connection.
+
+The same rule applies when an old connection exists but its authorization is expired or invalid.
+
+Do not automatically patch a pre-existing shell to point at the newly created connection unless the user explicitly wants that exact shell replaced.
+
+Reason:
+- it keeps shell ownership and account identity clear
+- it avoids silently repointing an existing reusable scenario from one account to another
+- it generalizes across email, CRM, ticketing, and other SaaS providers
 
 ## Recommended V2 request style
 
@@ -89,6 +141,8 @@ Once the chosen connection exists:
 3. update the scenario
 4. activate it if needed
 5. run a verification execution
+
+If a reusable shell scenario already exists, prefer patching that shell only when reusing an existing suitable connection. If the connection is newly created, create a new shell for that new connection.
 
 ## What to record before patching
 

--- a/skills/make-api-shell-connection-workflow/discovery-and-shells.md
+++ b/skills/make-api-shell-connection-workflow/discovery-and-shells.md
@@ -15,6 +15,8 @@ The middle module is the only app-specific part.
 
 This goal is about shell provisioning, not about proving the final business retrieval output. Retrieval strategy and output normalization come after the shell or native module path is connection-ready.
 
+The shell described here is generic for any SaaS provider that exposes an app-specific Make API-call module. It is a reusable API transport scenario, not a business-specific scenario.
+
 ## Source of truth
 
 Use current Make metadata as the source of truth.
@@ -64,9 +66,11 @@ Typical mapper:
 }
 ```
 
-Depending on the package, `{{3}}` or `{{3.data}}` may be more useful, but `{{3.body}}` is a reasonable default starting point for many API-call modules.
+For the generic API shell contract, `{{3.body}}` is not just a heuristic. It is the intended transport contract.
 
-That mapper is only a starting hypothesis. Validate it against a real execution bundle before treating it as final.
+Do not replace it with `{{3}}` or `{{3.data}}` inside this generic shell pattern.
+
+Use bundle inspection only to confirm that `body` contains the expected payload or error object. Do not use bundle inspection to redefine the generic shell contract.
 
 ## Activation readiness rule
 
@@ -203,7 +207,15 @@ Keep these separate:
 - Shell output contract: a transport shape for passing data through `ReturnData`
 - Retrieval output contract: the user-facing payload for messages, records, issues, or tickets
 
-The shell may activate successfully while still returning an unusable payload for the business question. That is a retrieval/output-normalization problem, not a connection-provisioning success.
+For this generic shell pattern, the shell output contract is fixed:
+
+```json
+{
+  "data": "{{3.body}}"
+}
+```
+
+The shell may activate successfully while still returning an unusable payload for the business question. That is a retrieval/output-normalization problem, not a shell-contract problem.
 
 ## Safety gate for write operations
 

--- a/skills/make-api-shell-connection-workflow/discovery-and-shells.md
+++ b/skills/make-api-shell-connection-workflow/discovery-and-shells.md
@@ -56,6 +56,11 @@ Expose these inputs:
 - `header`
 - `body`
 
+Important:
+- treat this as module-level intent, not as proof that the scenario-level interface is deployed
+- after creating or updating the scenario, explicitly set `/api/v2/scenarios/{scenarioId}/interface`
+- verify the deployed interface before the first `/run` call
+
 ### Module 2: app-specific API-call module
 Examples only:
 - Gmail: `google-email:makeAnApiCall`
@@ -73,6 +78,19 @@ Typical mapper:
 ```
 
 Default retrieval should use `GET`. Treat `PUT`, `PATCH`, and `DELETE` as write/destructive methods and require explicit user confirmation before running them.
+
+### Body-mapper compatibility rule
+
+The generic shell exposes `body`, but some provider modules do not behave well when `body` is present and empty on read-style calls.
+
+Use this decision rule:
+- default shell template: include the `body` mapper
+- if the provider module serializes empty/null bodies badly on `GET` or `DELETE`, remove the Module 2 `body` mapper for the read shell
+- keep or reintroduce the `body` mapper for write shells that need request payloads
+
+This is a provider-module compatibility choice, not a reason to change the generic shell output contract.
+
+Confirmed example to remember, but not to universalize: `google-calendar:makeApiCall` v5 has been observed to work better when a read/delete shell omits the `body` mapper entirely.
 
 ### Module 3: ReturnData
 Use:
@@ -147,8 +165,26 @@ Run scenario:
 Inspect interface:
 - `GET /api/v2/scenarios/{scenarioId}/interface`
 
+Set interface:
+- `PATCH /api/v2/scenarios/{scenarioId}/interface`
+
 Inspect blueprint:
 - `GET /api/v2/scenarios/{scenarioId}/blueprint`
+
+For on-demand API shells, do not stop after scenario create or update. Explicitly patch the scenario-level interface, then verify it:
+
+```json
+{
+  "input": [
+    { "name": "path", "type": "text", "required": false, "label": "Path" },
+    { "name": "method", "type": "text", "required": false, "label": "Method" },
+    { "name": "header", "type": "any", "required": false, "label": "Header" },
+    { "name": "body", "type": "any", "required": false, "label": "Body" }
+  ]
+}
+```
+
+Reason: `StartSubscenario.metadata.interface` documents the shell shape, but it does not reliably deploy the scenario-level run interface by itself. Treat `PATCH /interface` as mandatory for reusable on-demand shells.
 
 ## Base URL and zone
 
@@ -262,6 +298,23 @@ Document both values explicitly before building or patching the shell.
 
 Before creating any credential request, check whether the workspace already has a usable connection for the app.
 
+Do not stop at “same vendor”. Check structural compatibility:
+- same app family and connection family required by the discovered module
+- same target account identity when available
+- same or broader scope set than the requested operation needs
+- no evidence that the connection is expired, revoked, or otherwise invalid
+
+If the tooling exposes detailed connection metadata, inspect it before testing reuse. Useful evidence includes:
+- connection type
+- account or accountName
+- scope list or scope count
+- last validation or health indicators when available
+
+Common examples:
+- Gmail-style module: `google-email:makeAnApiCall` usually expects `account:google-email`; do not assume a generic `google` connection is interchangeable
+- Google workspace app modules such as Calendar/Sheets/Drive often use `account:google`; do not assume a Gmail-specific connection is interchangeable
+- Microsoft mail modules commonly use `account:azure`
+
 For the REST API, filter `/api/v2/connections` with `type` or `type[]`:
 
 ```bash
@@ -289,10 +342,13 @@ Look for a scenario that has all of the following:
 
 Prefer reusing a shell when:
 - the module slug and app version still match current metadata
+- the shell is still bound to the same app family and connection family
 - the scenario interface still exposes `path`, `method`, `header`, and `body`
 - the shell is already linked to a suitable connection or can be patched safely
 
 Do not reuse a shell for a newly created connection. When the connection is new, create a new shell dedicated to that connection.
+
+Do not treat “same SaaS vendor” as enough for shell reuse. A Gmail shell, a Google Calendar shell, and a Google Sheets shell may all live under Google but still require different Make apps, different module slugs, and different connection families.
 
 Only create a new shell when:
 - no matching shell exists
@@ -321,7 +377,9 @@ Record these values before deciding to reuse or create:
 9. Reconcile the middle-module metadata against a real current module blueprint for the same app/version.
 10. Create the scenario when required by the shell-reuse rule.
 11. Patch the selected existing connection only when reusing an existing shell.
-12. Activate and run the scenario.
+12. Explicitly set the scenario-level interface.
+13. Verify the interface.
+14. Activate and run the scenario.
 
 ## Shell output vs. retrieval output
 

--- a/skills/make-api-shell-connection-workflow/discovery-and-shells.md
+++ b/skills/make-api-shell-connection-workflow/discovery-and-shells.md
@@ -2,6 +2,8 @@
 
 This file covers how to discover the correct Make app and module, distinguish connection type layers, and build the reusable shell blueprint.
 
+It does not guarantee that the first generic shell draft is directly activatable. Treat the generic blueprint as a starting template that must be reconciled with current app-specific metadata.
+
 ## Goal
 
 Build one reusable scenario pattern for many apps:
@@ -10,6 +12,8 @@ Build one reusable scenario pattern for many apps:
 - `scenario-service:ReturnData`
 
 The middle module is the only app-specific part.
+
+This goal is about shell provisioning, not about proving the final business retrieval output. Retrieval strategy and output normalization come after the shell or native module path is connection-ready.
 
 ## Source of truth
 
@@ -61,6 +65,25 @@ Typical mapper:
 ```
 
 Depending on the package, `{{3}}` or `{{3.data}}` may be more useful, but `{{3.body}}` is a reasonable default starting point for many API-call modules.
+
+That mapper is only a starting hypothesis. Validate it against a real execution bundle before treating it as final.
+
+## Activation readiness rule
+
+Do not assume a minimal middle-module block is valid just because the slug and mapper are correct.
+
+Before activation, compare the generated middle module with current evidence from the same app and version in the active workspace, such as:
+- a current scenario blueprint that already uses the module
+- current module metadata from Make
+- a current exported module block from the same app/version
+
+Specifically verify whether the module requires app-specific metadata structures such as:
+- `expect`
+- `metadata.restore.expect`
+- connection restore blocks
+- parameter restore hints
+
+If activation returns a generic validation error such as `Scenario contains errors`, inspect the live blueprint and reconcile the metadata structure before retrying.
 
 ## Important discovery rule
 
@@ -167,10 +190,20 @@ Document both values explicitly before building or patching the shell.
 2. Discover the exact app name, version, and API-call module slug.
 3. Determine both connection type layers.
 4. Generate the three-module shell blueprint.
-5. Create the scenario.
-6. Create or resolve the credential request.
-7. Patch the scenario with the selected connection after authorization.
-8. Activate and run the scenario.
+5. Reconcile the middle-module metadata against a real current module blueprint for the same app/version.
+6. Create the scenario.
+7. Create or resolve the credential request.
+8. Patch the scenario with the selected connection after authorization.
+9. Activate and run the scenario.
+
+## Shell output vs. retrieval output
+
+Keep these separate:
+
+- Shell output contract: a transport shape for passing data through `ReturnData`
+- Retrieval output contract: the user-facing payload for messages, records, issues, or tickets
+
+The shell may activate successfully while still returning an unusable payload for the business question. That is a retrieval/output-normalization problem, not a connection-provisioning success.
 
 ## Safety gate for write operations
 

--- a/skills/make-api-shell-connection-workflow/discovery-and-shells.md
+++ b/skills/make-api-shell-connection-workflow/discovery-and-shells.md
@@ -13,7 +13,7 @@ Build one reusable scenario pattern for many apps:
 
 The middle module is the only app-specific part.
 
-This goal is about shell provisioning, not about proving the final business retrieval output. Retrieval strategy and output normalization come after the shell or native module path is connection-ready.
+This goal is about shell provisioning, not about proving the final business retrieval output. Retrieval strategy and output normalization come after the shell is connection-ready.
 
 The shell described here is generic for any SaaS provider that exposes an app-specific Make API-call module. It is a reusable API transport scenario, not a business-specific scenario.
 
@@ -26,6 +26,23 @@ Preferred evidence sources:
 3. current connection listing behavior in the active workspace
 
 Local notes, old blueprints, and example apps are only hints.
+
+## Provider-to-app resolution
+
+When the user asks for business data such as emails, CRM records, or tickets, do not start with shell creation.
+
+Resolve the app in this order:
+1. explicit user statement about the provider or system
+2. existing Make artifacts that unambiguously prove the provider and account
+3. Make app-catalog lookup for the provider candidate
+4. if still ambiguous, ask only for the missing provider or account identity
+
+Examples:
+- `Get my emails from user@example.com on Gmail` already gives both the provider and the account target
+- `Get my emails from today` does not; resolve provider and account first
+- `Get my open leads` requires provider resolution such as HubSpot vs Salesforce before any shell work
+
+Do not invent a provider from the business object alone.
 
 ## Standard shell contract
 
@@ -54,6 +71,8 @@ Typical mapper:
   "body": "{{2.body}}"
 }
 ```
+
+Default retrieval should use `GET`. Treat `PUT`, `PATCH`, and `DELETE` as write/destructive methods and require explicit user confirmation before running them.
 
 ### Module 3: ReturnData
 Use:
@@ -110,6 +129,8 @@ List apps:
 Get one app in detail:
 - `GET /api/v2/imt/apps/{appName}/{version}`
 
+Use the app-catalog endpoint to prove that the provider exists in Make for the active organization/team context before provisioning a shell.
+
 ### Scenario APIs
 Create scenario:
 - `POST /api/v2/scenarios?confirmed=true`
@@ -131,7 +152,22 @@ Inspect blueprint:
 
 ## Base URL and zone
 
-Ask the user which Make zone or base URL applies if it is not already known from the environment.
+Do not treat a successful user-scoped endpoint as proof that the workspace zone is correct.
+
+Observed practical behavior:
+- `GET /api/v2/users/me` can return `200` on multiple zones
+- `GET /api/v2/imt/apps/...` can also return `200` on multiple zones
+- team-scoped endpoints such as `GET /api/v2/connections?teamId=...` can still fail with `403 Permission denied` on the wrong zone
+
+Therefore resolve the zone before team-scoped work.
+
+Preferred order:
+1. infer the probable zone from the user's dashboard URL if provided
+2. list organizations on that zone
+3. list teams for the matching organization
+4. confirm with a team-scoped read such as `GET /api/v2/connections?teamId=TEAM_ID`
+
+Ask the user which Make zone or base URL applies only if it is still not recoverable from the environment or their provided links.
 For generic examples, define:
 
 ```bash
@@ -139,6 +175,40 @@ BASE_URL="https://us1.make.com"
 ```
 
 Then use that variable consistently in examples. Replace it with the actual zone only when the user provides or confirms it.
+
+### Resolve organizations and teams
+
+List organizations first:
+
+```bash
+curl -sS \
+  -H "authorization: Token $API_KEY" \
+  -H 'accept: application/json' \
+  -H 'user-agent: Mozilla/5.0' \
+  "${BASE_URL}/api/v2/organizations"
+```
+
+Then list teams for the organization that owns the target workspace:
+
+```bash
+curl -sS \
+  -H "authorization: Token $API_KEY" \
+  -H 'accept: application/json' \
+  -H 'user-agent: Mozilla/5.0' \
+  "${BASE_URL}/api/v2/teams?organizationId=${ORG_ID}"
+```
+
+Finally confirm the zone with a team-scoped call:
+
+```bash
+curl -sS \
+  -H "authorization: Token $API_KEY" \
+  -H 'accept: application/json' \
+  -H 'user-agent: Mozilla/5.0' \
+  "${BASE_URL}/api/v2/connections?teamId=${TEAM_ID}"
+```
+
+If that final call returns `403 Permission denied`, treat the zone as wrong or the team as inaccessible and stop guessing.
 
 ## Discover the app and module
 
@@ -188,17 +258,70 @@ Examples:
 
 Document both values explicitly before building or patching the shell.
 
+## Existing-connection preflight
+
+Before creating any credential request, check whether the workspace already has a usable connection for the app.
+
+For the REST API, filter `/api/v2/connections` with `type` or `type[]`:
+
+```bash
+curl -sS \
+  -H "authorization: Token $API_KEY" \
+  -H 'accept: application/json' \
+  -H 'user-agent: Mozilla/5.0' \
+  "${BASE_URL}/api/v2/connections?teamId=${TEAM_ID}&type[]=google-email"
+```
+
+Notes:
+- `type=google-email` and `type[]=google-email` are both accepted by the REST endpoint
+- do not assume `accountName=google-email` will filter correctly in REST just because Make MCP tooling uses `accountName` terminology
+- only create a credential request when no suitable existing connection is available for the target app and scope
+
+## Existing-shell preflight
+
+Before creating a new shell scenario, check whether the active team already has one that matches the generic shell contract.
+
+Look for a scenario that has all of the following:
+- `scenario-service:StartSubscenario`
+- the exact app-specific API-call module for the resolved app and version
+- `scenario-service:ReturnData`
+- on-demand execution or another explicit reusable shell shape
+
+Prefer reusing a shell when:
+- the module slug and app version still match current metadata
+- the scenario interface still exposes `path`, `method`, `header`, and `body`
+- the shell is already linked to a suitable connection or can be patched safely
+
+Do not reuse a shell for a newly created connection. When the connection is new, create a new shell dedicated to that connection.
+
+Only create a new shell when:
+- no matching shell exists
+- the existing shell uses the wrong app, wrong module slug, or wrong contract
+- the existing shell cannot be patched safely without breaking a live flow
+- a new connection has just been created for a new account or authorization context
+- the old connection exists but authorization failed because it is expired or invalid
+
+Record these values before deciding to reuse or create:
+- scenario ID
+- scenario name
+- app name and version
+- middle-module slug
+- whether the current `ReturnData` mapper still returns `{{3.body}}`
+
 ## Practical workflow
 
 1. Identify the target app.
-2. Discover the exact app name, version, and API-call module slug.
-3. Determine both connection type layers.
-4. Generate the three-module shell blueprint.
-5. Reconcile the middle-module metadata against a real current module blueprint for the same app/version.
-6. Create the scenario.
-7. Create or resolve the credential request.
-8. Patch the scenario with the selected connection after authorization.
-9. Activate and run the scenario.
+2. Prove that the target provider exists in the Make app catalog for the active organization/team.
+3. Discover the exact app name, version, and API-call module slug.
+4. Determine both connection type layers.
+5. Check whether a suitable connection already exists.
+6. Check whether a matching shell scenario already exists for that existing connection.
+7. Create or resolve the credential request only if a suitable connection does not already exist.
+8. Generate the three-module shell blueprint when no reusable shell exists or when a new connection has just been created.
+9. Reconcile the middle-module metadata against a real current module blueprint for the same app/version.
+10. Create the scenario when required by the shell-reuse rule.
+11. Patch the selected existing connection only when reusing an existing shell.
+12. Activate and run the scenario.
 
 ## Shell output vs. retrieval output
 

--- a/skills/make-api-shell-connection-workflow/discovery-and-shells.md
+++ b/skills/make-api-shell-connection-workflow/discovery-and-shells.md
@@ -1,0 +1,185 @@
+# Discovery and Shells
+
+This file covers how to discover the correct Make app and module, distinguish connection type layers, and build the reusable shell blueprint.
+
+## Goal
+
+Build one reusable scenario pattern for many apps:
+- `scenario-service:StartSubscenario`
+- one app-specific `Make an API Call` style module in the middle
+- `scenario-service:ReturnData`
+
+The middle module is the only app-specific part.
+
+## Source of truth
+
+Use current Make metadata as the source of truth.
+Preferred evidence sources:
+1. current IMT app metadata
+2. current module metadata from Make MCP or Make APIs
+3. current connection listing behavior in the active workspace
+
+Local notes, old blueprints, and example apps are only hints.
+
+## Standard shell contract
+
+### Module 1: StartSubscenario
+Use:
+- `scenario-service:StartSubscenario`
+
+Expose these inputs:
+- `path`
+- `method`
+- `header`
+- `body`
+
+### Module 2: app-specific API-call module
+Examples only:
+- Gmail: `google-email:makeAnApiCall`
+- Outlook: `microsoft-email:makeApiCall`
+- HubSpot: `hubspotcrm:MakeAPICall`
+
+Typical mapper:
+```json
+{
+  "url": "{{2.path}}",
+  "method": "{{2.method}}",
+  "headers": "{{2.header}}",
+  "body": "{{2.body}}"
+}
+```
+
+### Module 3: ReturnData
+Use:
+- `scenario-service:ReturnData`
+
+Typical mapper:
+```json
+{
+  "data": "{{3.body}}"
+}
+```
+
+Depending on the package, `{{3}}` or `{{3.data}}` may be more useful, but `{{3.body}}` is a reasonable default starting point for many API-call modules.
+
+## Important discovery rule
+
+The API-call module name is not standardized across apps.
+Common variants include:
+- `makeAnApiCall`
+- `makeApiCall`
+- `MakeAPICall`
+- `MakeAnAPICall`
+- `ActionMakeAnApiCall`
+
+Never guess the exact name or casing.
+
+## API surfaces
+
+### IMT app discovery
+List apps:
+- `GET /api/v2/imt/apps?organizationId=ORG_ID&teamId=TEAM_ID&scoredSearch=true`
+
+Get one app in detail:
+- `GET /api/v2/imt/apps/{appName}/{version}`
+
+### Scenario APIs
+Create scenario:
+- `POST /api/v2/scenarios?confirmed=true`
+
+Update scenario:
+- `PATCH /api/v2/scenarios/{scenarioId}?confirmed=true`
+
+Activate scenario:
+- `POST /api/v2/scenarios/{scenarioId}/start`
+
+Run scenario:
+- `POST /api/v2/scenarios/{scenarioId}/run`
+
+Inspect interface:
+- `GET /api/v2/scenarios/{scenarioId}/interface`
+
+Inspect blueprint:
+- `GET /api/v2/scenarios/{scenarioId}/blueprint`
+
+## Base URL and zone
+
+Ask the user which Make zone or base URL applies if it is not already known from the environment.
+For generic examples, define:
+
+```bash
+BASE_URL="https://us1.make.com"
+```
+
+Then use that variable consistently in examples. Replace it with the actual zone only when the user provides or confirms it.
+
+## Discover the app and module
+
+### Step 1: list candidate apps
+```bash
+curl -sS \
+  -H "authorization: Token $API_KEY" \
+  -H 'accept: application/json' \
+  "${BASE_URL}/api/v2/imt/apps?organizationId=${ORG_ID}&teamId=${TEAM_ID}&scoredSearch=true"
+```
+
+### Step 2: find apps exposing API-call modules
+Search module names case-insensitively for strings such as:
+- `makeapicall`
+- `makeanapicall`
+
+### Step 3: inspect one app in detail
+Example:
+```bash
+curl -sS \
+  -H "authorization: Token $API_KEY" \
+  -H 'accept: application/json' \
+  "${BASE_URL}/api/v2/imt/apps/hubspotcrm/2"
+```
+
+Confirm:
+- exact app name
+- app version
+- exact module slug and casing
+- any module-specific parameter shape that differs from the standard mapper
+
+## Two different type layers
+
+Do not mix these concepts.
+
+### 1. Scenario or module connection parameter type
+Used in blueprint metadata or module restore data.
+Examples:
+- `account:google-email`
+- `account:azure`
+
+### 2. Connection listing or credential request type
+Used when listing connections or creating fallback credential requests.
+Examples:
+- `google-email`
+- `azure`
+
+Document both values explicitly before building or patching the shell.
+
+## Practical workflow
+
+1. Identify the target app.
+2. Discover the exact app name, version, and API-call module slug.
+3. Determine both connection type layers.
+4. Generate the three-module shell blueprint.
+5. Create the scenario.
+6. Create or resolve the credential request.
+7. Patch the scenario with the selected connection after authorization.
+8. Activate and run the scenario.
+
+## Safety gate for write operations
+
+Before any operation that changes a live scenario, ask for explicit confirmation.
+Keep it short and concrete:
+
+```text
+You asked me to update an existing Make scenario.
+Risk: this can replace a module mapper or connection value and break a live flow until it is repaired.
+Example: changing the API-call module connection could stop the shell from authenticating until the correct connection is restored.
+Reply with YES to proceed, or tell me what to change first.
+```

--- a/skills/make-api-shell-connection-workflow/examples/generic-api-shell-blueprint.json
+++ b/skills/make-api-shell-connection-workflow/examples/generic-api-shell-blueprint.json
@@ -54,6 +54,6 @@
   ],
   "metadata": {
     "version": 1,
-    "notes": "Template only. Replace placeholders with discovered app and connection data before deployment. This file is a provisioning starter, not proof that the scenario is activatable or that retrieval output mapping is correct. Validate middle-module metadata and ReturnData mapping against a real execution bundle."
+    "notes": "Template only. Replace placeholders with discovered app and connection data before deployment. This file is a provisioning starter, not proof that the scenario is activatable. For the generic shell contract, keep ReturnData mapped to {{3.body}} so ExpectDataAny receives the raw response body; validate runs to confirm body contains the intended payload or error object."
   }
 }

--- a/skills/make-api-shell-connection-workflow/examples/generic-api-shell-blueprint.json
+++ b/skills/make-api-shell-connection-workflow/examples/generic-api-shell-blueprint.json
@@ -54,6 +54,6 @@
   ],
   "metadata": {
     "version": 1,
-    "notes": "Template only. Replace placeholders with discovered app and connection data before deployment. This file is a provisioning starter, not proof that the scenario is activatable. For the generic shell contract, keep ReturnData mapped to {{3.body}} so ExpectDataAny receives the raw response body; validate runs to confirm body contains the intended payload or error object."
+    "notes": "Template only. Replace placeholders with discovered app and connection data before deployment. This file is a provisioning starter, not proof that the scenario is activatable. After create or update, explicitly patch the scenario-level interface before the first run. For the generic shell contract, keep ReturnData mapped to {{3.body}} so ExpectDataAny receives the raw response body; validate runs to confirm body contains the intended payload or error object. If a provider module mishandles empty bodies on GET or DELETE, keep this shell contract but consider a read shell without the Module 2 body mapper and a separate write shell with it."
   }
 }

--- a/skills/make-api-shell-connection-workflow/examples/generic-api-shell-blueprint.json
+++ b/skills/make-api-shell-connection-workflow/examples/generic-api-shell-blueprint.json
@@ -34,7 +34,7 @@
         "designer": { "x": 300, "y": 0 },
         "restore": {
           "expectUserSelection": true,
-          "notes": "Replace module name, version, and connection metadata with values discovered from the active workspace."
+          "notes": "Replace module name, version, and connection metadata with values discovered from the active workspace. Reconcile any app-specific expect or restore structures against a real current blueprint before activation."
         }
       }
     },
@@ -54,6 +54,6 @@
   ],
   "metadata": {
     "version": 1,
-    "notes": "Template only. Replace placeholders with discovered app and connection data before deployment."
+    "notes": "Template only. Replace placeholders with discovered app and connection data before deployment. This file is a provisioning starter, not proof that the scenario is activatable or that retrieval output mapping is correct. Validate middle-module metadata and ReturnData mapping against a real execution bundle."
   }
 }

--- a/skills/make-api-shell-connection-workflow/examples/generic-api-shell-blueprint.json
+++ b/skills/make-api-shell-connection-workflow/examples/generic-api-shell-blueprint.json
@@ -1,0 +1,59 @@
+{
+  "name": "Generic API Shell",
+  "flow": [
+    {
+      "id": 2,
+      "module": "scenario-service:StartSubscenario",
+      "version": 2,
+      "parameters": {},
+      "mapper": {},
+      "metadata": {
+        "designer": { "x": 0, "y": 0 },
+        "restore": {},
+        "interface": [
+          { "name": "path", "type": "text", "required": false, "multiline": false },
+          { "name": "body", "type": "any", "required": false },
+          { "name": "header", "type": "any", "required": false },
+          { "name": "method", "type": "text", "required": false, "multiline": false }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "module": "APP_NAME:API_CALL_MODULE_NAME",
+      "version": 1,
+      "parameters": {},
+      "filter": null,
+      "mapper": {
+        "url": "{{2.path}}",
+        "method": "{{2.method}}",
+        "headers": "{{2.header}}",
+        "body": "{{2.body}}"
+      },
+      "metadata": {
+        "designer": { "x": 300, "y": 0 },
+        "restore": {
+          "expectUserSelection": true,
+          "notes": "Replace module name, version, and connection metadata with values discovered from the active workspace."
+        }
+      }
+    },
+    {
+      "id": 4,
+      "module": "scenario-service:ReturnData",
+      "version": 1,
+      "parameters": {},
+      "mapper": {
+        "data": "{{3.body}}"
+      },
+      "metadata": {
+        "designer": { "x": 600, "y": 0 },
+        "restore": {}
+      }
+    }
+  ],
+  "metadata": {
+    "version": 1,
+    "notes": "Template only. Replace placeholders with discovered app and connection data before deployment."
+  }
+}

--- a/skills/make-api-shell-connection-workflow/retrieval-execution.md
+++ b/skills/make-api-shell-connection-workflow/retrieval-execution.md
@@ -50,7 +50,52 @@ This is the default execution contract for the shell across providers.
 
 The concrete `path` changes by provider, but the scenario-run payload shape stays the same.
 
+Important deployment precondition:
+- do not assume the `StartSubscenario` module metadata alone made this callable
+- explicitly set the scenario-level input interface first
+- verify `/api/v2/scenarios/{scenarioId}/interface` before the first run
+
+The keys under `data` must match the deployed interface exactly. For reusable shells, the standard execution path is:
+1. `PATCH /api/v2/scenarios/{scenarioId}/interface`
+2. `GET /api/v2/scenarios/{scenarioId}/interface`
+3. `POST /api/v2/scenarios/{scenarioId}/run`
+
+Use `responsive: true` for validation runs and for normal interactive retrieval whenever the response size is still manageable.
+
 Default retrieval should use `GET`. Treat `PUT`, `PATCH`, and `DELETE` as write/destructive methods and require explicit user confirmation before running them.
+
+## Large payloads, timeouts, and extraction path
+
+Two separate limits matter here:
+- Make scenario execution limits and provider API limits during the run
+- post-run inspection limits when reading full execution detail
+
+Practical guidance:
+1. Start with the narrowest possible list/search call.
+2. Prefer `responsive: true` so the shell returns the business payload directly when feasible.
+3. Read the returned payload from `outputs.data` first instead of forcing an execution-detail round trip.
+4. Add provider-side narrowing such as `limit`, `maxResults`, `pageSize`, `fields`, `updatedSince`, or a search query before trying to inspect giant payloads.
+5. Split list/search from detail enrichment instead of fetching everything in one run.
+
+Do not treat a timeout or a heavy `executions_get-detail` response as evidence that the shell contract is wrong. First narrow the retrieval and reduce payload size.
+
+## Rate limiting and write safety
+
+Even when `scenarios_run` itself is exempt from an organization's general request-rate bucket, provider APIs behind Module 2 still enforce their own limits.
+
+Generic operating rules:
+- rate-limit write methods more aggressively than reads
+- use backoff and replay for 429-style provider errors
+- keep batch sizes modest on detail-enrichment loops
+- separate read-heavy and write-heavy workloads when the provider module behaves differently
+
+Confirmed example to remember, but not to universalize: Google Calendar has been observed around the order of a few hundred requests per minute per user in some environments, which is high enough for bursts but still easy to exceed with naive fan-out. Treat provider documentation and live error responses as the actual source of truth.
+
+If a provider module shows empty-body serialization issues on `GET` or `DELETE`, split the shell design:
+- read/delete shell without a Module 2 `body` mapper
+- write shell with a Module 2 `body` mapper
+
+That split is about request-shape compatibility and rate safety, not about changing `ReturnData`.
 
 ## Common retrieval pattern for SaaS data
 

--- a/skills/make-api-shell-connection-workflow/retrieval-execution.md
+++ b/skills/make-api-shell-connection-workflow/retrieval-execution.md
@@ -6,34 +6,102 @@ Provisioning success is not the same thing as retrieval success. Treat retrieval
 
 ## Goal
 
-Given a connection-ready Make app or shell:
-- choose the best retrieval path
-- run a narrow validation request
+Given a connection-ready Make API-call shell:
+- configure the right API path pattern for the business request
+- run a narrow validation request through the shell
 - inspect the real output bundle
 - normalize the result for Hermes or the user-facing caller
 
-## Retrieval strategy ladder
+## Retrieval transport rule
 
-Prefer this order unless current metadata proves a different path is required:
-1. provider-native search or list modules for the first retrieval step
-2. provider-native get/detail modules for follow-up enrichment
-3. generic API-call shell only when native retrieval modules are missing, insufficient, or too restrictive for the endpoint the user needs
+For this workflow family, the Make API-call shell is always the retrieval transport.
 
-Examples of native retrieval families:
-- email providers: search/list messages, then get message detail
-- CRM providers: search/list records, then get record detail
-- issue trackers: search/list issues, then get issue detail
+Do not switch to provider-native Make search/list/get modules for the first retrieval step or for follow-up enrichment.
 
-Do not assume the API-call shell used during provisioning is also the best retrieval path.
+If the business request needs multiple steps, perform all of them through repeated runs of the API-call shell.
 
 ## Execution workflow
 
 1. Confirm the provider and the exact Make app version again.
-2. Choose the retrieval module family that best matches the business request.
-3. Run the narrowest possible validation call first.
-4. Inspect the real output bundle from that run.
-5. Map `scenario-service:ReturnData` from the observed bundle shape, not from guesswork.
-6. Re-run and verify the final payload.
+2. Resolve the business target precisely: mailbox, inbox, account, pipeline, board, queue, or project.
+3. Choose the API endpoint pattern that best matches the business request.
+4. Run the narrowest possible validation call first through the shell.
+5. Inspect the real output bundle from that run.
+6. Keep `scenario-service:ReturnData` fixed to the generic shell contract and adjust only downstream normalization.
+7. Re-run and verify the final payload.
+
+## Generic shell run contract
+
+When using the generic three-module shell, run it with a payload shaped like this:
+
+```json
+{
+  "data": {
+    "path": "...",
+    "method": "GET",
+    "header": [],
+    "body": null
+  },
+  "responsive": true
+}
+```
+
+This is the default execution contract for the shell across providers.
+
+The concrete `path` changes by provider, but the scenario-run payload shape stays the same.
+
+Default retrieval should use `GET`. Treat `PUT`, `PATCH`, and `DELETE` as write/destructive methods and require explicit user confirmation before running them.
+
+## Common retrieval pattern for SaaS data
+
+For most business retrieval tasks, use this pattern through the API-call shell:
+
+1. Run a narrow list/search call first.
+2. Collect stable identifiers from that first result.
+3. Run follow-up detail calls only for the shortlisted records.
+4. Normalize the detail payload into a user-facing summary.
+
+This keeps the first execution cheap, proves that the shell works, and avoids over-fetching.
+
+### Email pattern
+
+Use:
+1. list or search messages/threads with a narrow filter
+2. fetch message detail only for the returned IDs or thread IDs
+3. normalize sender, subject, date, labels, snippet, and whether a reply seems needed
+
+### CRM pattern
+
+Use:
+1. search or list records with a narrow filter such as owner, stage, or updated-after
+2. fetch detail only for the returned record IDs
+3. normalize owner, company/contact, stage, last activity, next action, and urgency
+
+### Ticketing pattern
+
+Use:
+1. search or list issues or tickets with a narrow filter such as assignee, state, queue, or updated-after
+2. fetch detail only for the shortlisted IDs
+3. normalize requester, status, SLA or priority, latest comment, and next action
+
+## Suggested normalization contract
+
+For user-facing summaries, normalize the provider payload into a stable business shape whenever practical:
+
+```json
+{
+  "id": "provider-specific-id",
+  "title": "subject or record title",
+  "actor": "sender, requester, owner, or customer",
+  "status": "state or stage",
+  "updatedAt": "timestamp",
+  "summary": "snippet or compact summary",
+  "recommendedAction": "reply | inspect | ignore",
+  "reason": "why that action is recommended"
+}
+```
+
+The shell still returns raw `body`. This normalization happens after retrieval, not inside the shell contract.
 
 ## Output-mapping rule
 
@@ -67,22 +135,13 @@ Only after the body has been returned through the generic shell may you decide h
 
 If `data: null`, a bare number, or another unusable shape appears, first ask:
 1. did the generic shell still return `{{3.body}}`?
-2. is the provider-native module a better retrieval path than the generic API shell?
+2. did the API path, method, headers, or body match the provider requirement?
 3. is the downstream interpreter reading the body correctly?
+
+If the failure is actually an authorization failure from an expired or invalid connection, stop retrieval debugging and go back to the credential-request path instead of trying to re-auth the old connection in place.
 
 Do not redefine the generic shell contract to compensate for a retrieval problem.
 
-## Raw API vs native retrieval modules
-
-Use raw API shell calls when:
-- the endpoint is custom or unsupported by native modules
-- the request shape must remain open-ended
-- native modules cannot express the needed filters or payload shape cleanly
-
-Use native search/get modules when:
-- the user wants normal business retrieval such as emails, leads, contacts, tickets, or issues
-- the provider already exposes modules that handle the search semantics cleanly
-- predictable bundles are needed for follow-up mapping or enrichment
 
 ## Failure interpretation
 
@@ -92,4 +151,4 @@ Keep failure diagnosis phase-specific:
 - empty or unusable payload from a successful run: retrieval or output-normalization problem
 
 If activation fails with a generic validation error, go back to shell metadata.
-If the run succeeds but the payload is wrong, stay in Make and fix the retrieval strategy or `ReturnData` mapping before considering fallback.
+If the run succeeds but the payload is wrong, stay in Make and fix the API-call plan or downstream normalization before considering fallback.

--- a/skills/make-api-shell-connection-workflow/retrieval-execution.md
+++ b/skills/make-api-shell-connection-workflow/retrieval-execution.md
@@ -37,19 +37,40 @@ Do not assume the API-call shell used during provisioning is also the best retri
 
 ## Output-mapping rule
 
-Do not finalize `ReturnData` until a real execution bundle has been seen.
+Do not mix the generic shell contract with retrieval-specific normalization.
 
-Common starting patterns:
-- `{{3.body}}` for many raw API-call modules that return a body object
-- `{{3}}` when the module returns the useful payload as the whole bundle
-- a specific property such as `{{3.data}}`, `{{3.messages}}`, or another discovered field only after current evidence shows that field exists
+### A. Generic API shell contract
 
-Signals that the mapping is wrong:
-- `data: null`
-- a bare number where structured data is expected
-- only transport metadata and no business payload
+For the three-module generic API transport shell:
 
-When this happens, inspect the run output and correct the mapping before calling the retrieval complete.
+```json
+{
+  "data": "{{3.body}}"
+}
+```
+
+That is the contract. It should stay stable across providers.
+
+Do not switch that generic contract to:
+- `{{3}}`
+- `{{3.data}}`
+- another guessed nested field
+
+### B. Retrieval-specific normalization
+
+Only after the body has been returned through the generic shell may you decide how to interpret the business payload:
+- messages
+- records
+- issues
+- tickets
+- errors
+
+If `data: null`, a bare number, or another unusable shape appears, first ask:
+1. did the generic shell still return `{{3.body}}`?
+2. is the provider-native module a better retrieval path than the generic API shell?
+3. is the downstream interpreter reading the body correctly?
+
+Do not redefine the generic shell contract to compensate for a retrieval problem.
 
 ## Raw API vs native retrieval modules
 

--- a/skills/make-api-shell-connection-workflow/retrieval-execution.md
+++ b/skills/make-api-shell-connection-workflow/retrieval-execution.md
@@ -1,0 +1,74 @@
+# Retrieval Execution
+
+This file covers what happens after connection provisioning succeeds.
+
+Provisioning success is not the same thing as retrieval success. Treat retrieval as a separate phase with its own strategy choice, validation run, and output normalization.
+
+## Goal
+
+Given a connection-ready Make app or shell:
+- choose the best retrieval path
+- run a narrow validation request
+- inspect the real output bundle
+- normalize the result for Hermes or the user-facing caller
+
+## Retrieval strategy ladder
+
+Prefer this order unless current metadata proves a different path is required:
+1. provider-native search or list modules for the first retrieval step
+2. provider-native get/detail modules for follow-up enrichment
+3. generic API-call shell only when native retrieval modules are missing, insufficient, or too restrictive for the endpoint the user needs
+
+Examples of native retrieval families:
+- email providers: search/list messages, then get message detail
+- CRM providers: search/list records, then get record detail
+- issue trackers: search/list issues, then get issue detail
+
+Do not assume the API-call shell used during provisioning is also the best retrieval path.
+
+## Execution workflow
+
+1. Confirm the provider and the exact Make app version again.
+2. Choose the retrieval module family that best matches the business request.
+3. Run the narrowest possible validation call first.
+4. Inspect the real output bundle from that run.
+5. Map `scenario-service:ReturnData` from the observed bundle shape, not from guesswork.
+6. Re-run and verify the final payload.
+
+## Output-mapping rule
+
+Do not finalize `ReturnData` until a real execution bundle has been seen.
+
+Common starting patterns:
+- `{{3.body}}` for many raw API-call modules that return a body object
+- `{{3}}` when the module returns the useful payload as the whole bundle
+- a specific property such as `{{3.data}}`, `{{3.messages}}`, or another discovered field only after current evidence shows that field exists
+
+Signals that the mapping is wrong:
+- `data: null`
+- a bare number where structured data is expected
+- only transport metadata and no business payload
+
+When this happens, inspect the run output and correct the mapping before calling the retrieval complete.
+
+## Raw API vs native retrieval modules
+
+Use raw API shell calls when:
+- the endpoint is custom or unsupported by native modules
+- the request shape must remain open-ended
+- native modules cannot express the needed filters or payload shape cleanly
+
+Use native search/get modules when:
+- the user wants normal business retrieval such as emails, leads, contacts, tickets, or issues
+- the provider already exposes modules that handle the search semantics cleanly
+- predictable bundles are needed for follow-up mapping or enrichment
+
+## Failure interpretation
+
+Keep failure diagnosis phase-specific:
+- connection request failure: provisioning problem
+- scenario activation failure: shell-provisioning problem
+- empty or unusable payload from a successful run: retrieval or output-normalization problem
+
+If activation fails with a generic validation error, go back to shell metadata.
+If the run succeeds but the payload is wrong, stay in Make and fix the retrieval strategy or `ReturnData` mapping before considering fallback.

--- a/skills/make-api-shell-connection-workflow/sanitization-and-sharing.md
+++ b/skills/make-api-shell-connection-workflow/sanitization-and-sharing.md
@@ -1,0 +1,78 @@
+# Sanitization and Sharing
+
+Use this checklist before installing a skill globally or contributing it to a shared repository.
+
+## Remove tenant-specific data
+
+Do not publish any of the following:
+- real user names
+- personal labels in `nameOverride`
+- team IDs
+- organization IDs
+- user IDs such as provider IDs
+- workspace-specific hosts such as a private Make workspace hostname
+- absolute local file paths from a personal machine
+
+Replace them with placeholders such as:
+- `TEAM_ID`
+- `ORG_ID`
+- `REQUEST_ID`
+- `SCENARIO_ID`
+- `BASE_URL`
+- `CONNECTION_ID`
+
+## Rewrite example labels
+
+Bad:
+- `personal-outlook-api-shell`
+- `gmail-shell-debug`
+- `tenant-scoped API shell execution`
+
+Better:
+- `outlook-api-shell`
+- `gmail-api-shell`
+- `generic API shell execution`
+
+## Rewrite evidence language
+
+Bad:
+- `verified live`
+- `worked in tenant X`
+- `confirmed from private reverse-engineering`
+
+Better:
+- `example observed during development`
+- `practical fallback`
+- `current workflow recommendation`
+- `workspace-specific behavior can vary`
+
+## Public documentation style
+
+Prefer wording like this:
+- `Use current Make metadata as the source of truth.`
+- `Examples are illustrative and should be validated in the active workspace.`
+- `If the preferred endpoint is unavailable, try the compatibility fallback.`
+
+Avoid wording like this:
+- `This exact request shape always works.`
+- `These values are confirmed globally.`
+- `This private workspace proves the rule for every tenant.`
+
+## Final pre-publish scan
+
+Search for and remove or replace:
+- personal names
+- email addresses
+- numeric IDs copied from private environments
+- `we.make.com`
+- `providerMakeUserId`
+- absolute home-directory paths copied from a personal machine
+- phrases such as `verified live`, `working example`, or `for debugging` if they imply private validation or tenant-specific state
+
+## Repository fit
+
+For public repositories:
+- keep `SKILL.md` concise
+- move detailed operational guidance into sibling markdown files
+- keep templates generic
+- use examples that teach the shape of the workflow without exposing private data

--- a/skills/make-api-shell-connection-workflow/sanitization-and-sharing.md
+++ b/skills/make-api-shell-connection-workflow/sanitization-and-sharing.md
@@ -64,7 +64,7 @@ Search for and remove or replace:
 - personal names
 - email addresses
 - numeric IDs copied from private environments
-- `we.make.com`
+- workspace-specific hosts; use `https://us1.make.com` as the public example base URL
 - `providerMakeUserId`
 - absolute home-directory paths copied from a personal machine
 - phrases such as `verified live`, `working example`, or `for debugging` if they imply private validation or tenant-specific state

--- a/skills/make-scenario-building/blueprint-construction.md
+++ b/skills/make-scenario-building/blueprint-construction.md
@@ -488,6 +488,8 @@ want to prevent formula evaluation.
 | `builtin:Ignore`   | Ignore error and continue     |
 | `builtin:Break`    | Move to incomplete executions |
 
+Use the exact token `builtin:Ignore`. Do not document or search for a separate `builtin:IgnoreError` directive; that name is not the canonical Make blueprint directive.
+
 ## Deployment Checklist
 
 After constructing a blueprint, follow this sequence to deploy and run it:


### PR DESCRIPTION
## Summary
- add the `make-api-shell-connection-workflow` skill
- document current provisioning vs retrieval guidance for Make API-call shells
- standardize public examples on `https://us1.make.com`
- clarify the generic shell contract around `data: {{3.body}}`
- include sanitization guidance and a warning before mutating Module 2 methods (`PUT`, `PATCH`, `DELETE`)

## Notes
- examples are sanitized for public sharing
- this PR adds the new skill files under `skills/make-api-shell-connection-workflow/`
- `POST` handling is intentionally left unchanged for now
