### PR TITLE
feat: update aggregator and AI tools documentation with known issues and template lookup guidance

### DIFF
--- a/skills/make-mcp-reference/SKILL.md
+++ b/skills/make-mcp-reference/SKILL.md
@@ -174,29 +174,6 @@ Default: 56 characters.
 | Permission denied | Check token scopes and access control parameters |
 | Connection refused | Verify zone URL and token validity |
 | Stale tool list | Reconnect MCP client to refresh available tools |
-| `Organization-bound request can't be used outside of the Organization Context` on `public-templates_get`, `public-templates_get-blueprint`, or RPC-backed validators | Known MCP server bug. Retry the call; if persistent, reconnect the make MCP server (`/mcp` reauth) and retry. If still failing, fall back: skip template lookup, or guess-and-test for RPC-backed values (see "Known MCP server bugs" below). |
-
-## Known MCP server bugs
-
-These are server-side issues with the Make MCP server itself, not configuration problems on the client. Document workarounds here and report upstream if patterns persist.
-
-### "Organization-bound request" errors
-
-Several endpoints intermittently fail with:
-- `MakeError: Organization-bound request can't be used outside of the Organization Context.`
-- `MakeError: Organization-bound RPC can't access resources outside of the Organization Context.`
-
-The schemas of the affected tools do NOT expose an `organizationId` parameter, so there's no way to supply context explicitly. The OAuth session should bind to an organization but doesn't reliably propagate to these endpoints.
-
-**Affected (observed 2026-05):**
-- `public-templates_get` and `public-templates_get-blueprint` — sometimes succeed on retry after `/mcp` reauth
-- `rpc_execute` for organization-bound RPCs (e.g., `RpcGetModels` for `ai-tools`) — consistently fails
-- `validate_module_configuration` when the validated module has dynamic fields backed by an org-bound RPC — fails with the same error wrapped inside the validation result
-
-**Workarounds:**
-1. **Retry after `/mcp` reauth.** Sometimes resolves the public-templates variants. The list endpoint (`public-templates_list`) is NOT affected — only the per-template get/get-blueprint variants.
-2. **Skip the failing validator.** When a module's strict validation fails purely because an RPC can't resolve, deploy anyway and rely on `scenarios_run` for empirical verification. The runtime error message names the offending field clearly (e.g., `Model X not allowed for Make AI Provider`).
-3. **Empirically test values.** For RPC-backed select fields (e.g., AI model dropdown), guess from documented patterns and run the scenario. Combine with the Make UI to inspect the dropdown labels for ground truth.
 
 ## Resources
 

--- a/skills/make-mcp-reference/SKILL.md
+++ b/skills/make-mcp-reference/SKILL.md
@@ -174,6 +174,29 @@ Default: 56 characters.
 | Permission denied | Check token scopes and access control parameters |
 | Connection refused | Verify zone URL and token validity |
 | Stale tool list | Reconnect MCP client to refresh available tools |
+| `Organization-bound request can't be used outside of the Organization Context` on `public-templates_get`, `public-templates_get-blueprint`, or RPC-backed validators | Known MCP server bug. Retry the call; if persistent, reconnect the make MCP server (`/mcp` reauth) and retry. If still failing, fall back: skip template lookup, or guess-and-test for RPC-backed values (see "Known MCP server bugs" below). |
+
+## Known MCP server bugs
+
+These are server-side issues with the Make MCP server itself, not configuration problems on the client. Document workarounds here and report upstream if patterns persist.
+
+### "Organization-bound request" errors
+
+Several endpoints intermittently fail with:
+- `MakeError: Organization-bound request can't be used outside of the Organization Context.`
+- `MakeError: Organization-bound RPC can't access resources outside of the Organization Context.`
+
+The schemas of the affected tools do NOT expose an `organizationId` parameter, so there's no way to supply context explicitly. The OAuth session should bind to an organization but doesn't reliably propagate to these endpoints.
+
+**Affected (observed 2026-05):**
+- `public-templates_get` and `public-templates_get-blueprint` — sometimes succeed on retry after `/mcp` reauth
+- `rpc_execute` for organization-bound RPCs (e.g., `RpcGetModels` for `ai-tools`) — consistently fails
+- `validate_module_configuration` when the validated module has dynamic fields backed by an org-bound RPC — fails with the same error wrapped inside the validation result
+
+**Workarounds:**
+1. **Retry after `/mcp` reauth.** Sometimes resolves the public-templates variants. The list endpoint (`public-templates_list`) is NOT affected — only the per-template get/get-blueprint variants.
+2. **Skip the failing validator.** When a module's strict validation fails purely because an RPC can't resolve, deploy anyway and rely on `scenarios_run` for empirical verification. The runtime error message names the offending field clearly (e.g., `Model X not allowed for Make AI Provider`).
+3. **Empirically test values.** For RPC-backed select fields (e.g., AI model dropdown), guess from documented patterns and run the scenario. Combine with the Make UI to inspect the dropdown labels for ground truth.
 
 ## Resources
 

--- a/skills/make-module-configuring/aggregators.md
+++ b/skills/make-module-configuring/aggregators.md
@@ -108,6 +108,7 @@ This back-and-forth is necessary because the aggregator's target variant needs t
 ## Gotchas
 
 - **Feeder is required.** Every aggregator must specify which module feeds it. Without a feeder, the aggregator doesn't know which loop to collect from.
+- **Validator-vs-blueprint mismatch on `feeder`.** `validate_module_configuration` rejects `parameters.feeder` as `"Unknown field 'feeder'"` even though it's required for the blueprint to deploy. This is a known mismatch — the per-module schema returned by `app-module_get` doesn't expose `feeder`, but the blueprint orchestration layer requires it. **Workaround:** skip the per-module validator for aggregators, OR run it without `feeder` (just to validate `rowSeparator`, `target`, mapper, etc.), then re-add `feeder` before deploying. Always verify with `validate_blueprint_schema` (whole-blueprint validator) — it accepts `feeder` correctly, and `scenarios_create` will too.
 - **Don't confuse feeder with source module ID in mapper.** The `feeder` parameter identifies the loop source. The mapper references (e.g., `{{2.email}}`) use the module ID of the module whose output fields are being collected — these are
   often the same module, but not always.
 - **Empty aggregations.** If the feeder produces zero bundles, the aggregator produces nothing by default. Use `stopIfEmpty: true` to halt the scenario, or handle the empty case downstream.

--- a/skills/make-scenario-building/SKILL.md
+++ b/skills/make-scenario-building/SKILL.md
@@ -86,6 +86,28 @@ If a tool is not found by exact name, search for similarly named tools on the Ma
 - **App version** (exact version as returned by the tool)
 - **Module name** (exact technical name/slug of each module you plan to use)
 
+### Step 2.5: Look Up Reference Templates
+
+Once apps and modules are identified, search the Make public template library for similar scenarios. Studying an existing template's blueprint reveals canonical module versions, mapper shapes, and aggregator/feeder bindings that aren't visible from `app-module_get` alone.
+
+**Recommended whenever the planned flow includes:**
+- An aggregator (`util:TextAggregator`, `builtin:BasicAggregator`, etc.)
+- A Make AI Tools module or any AI provider module
+- An app you haven't configured earlier in this session
+- Multi-module composition (more than 2-3 modules, branching, iteration)
+
+**Skip allowed for** single-module trigger → single-action flows with well-known apps and no aggregation/AI.
+
+**How:**
+1. `public-templates_list` with `name: <use-case keywords>` and `usedApps: <app slugs from Step 2>`
+2. If matches found, pick the highest-`usage` one with the most app overlap
+3. `public-templates_get-blueprint` to fetch the full structure
+4. Use as STRUCTURAL reference — NOT as the literal blueprint to copy. Templates often implement a slightly different pattern (e.g., per-item loop vs digest-style aggregation). Note diffs and present them to the user in Step 3.
+
+If `public-templates_get*` returns "Organization-bound request can't be used outside of the Organization Context", retry once; if it persists, reconnect the Make MCP server (`/mcp` reauth) and retry. If still failing, proceed without — the template is a nice-to-have reference, not a requirement.
+
+See [Templates Lookup](./templates-lookup.md) for search patterns, blueprint-diffing tips, and MCP workarounds.
+
 ### Step 3: Present the Module Composition & Get Confirmation
 
 Present the proposed module sequence to the user using **flowchart notation**:
@@ -323,7 +345,7 @@ This is the one valid use of date + literal time concatenation. The general rule
 
 ### Make AI Tools (`ai-tools:Ask`): Model Is Required, No Default
 
-The `model` parameter in `ai-tools:Ask` (and other Make AI Toolkit modules) is **required** — there is no default value. Omitting it causes a 400 error at runtime. When using Make's AI Provider (`ai-provider` connection), use tier names: `"low"`, `"medium"`, or `"high"`. Do not use provider-specific model IDs (e.g., `"gpt-4o-mini"`) with the Make AI Provider — they are not valid tier names and will fail.
+The `model` parameter in `ai-tools:Ask` (and other Make AI Toolkit modules) is **required** — there is no default value. Omitting it causes a 400 error at runtime. When using Make's AI Provider (`ai-provider` connection), use tier slug names: `"small"`, `"medium"`, or `"large"`. (Older docs mention `low/medium/high` — these are stale; the runtime rejects them with `Model X not allowed for Make AI Provider`.) Only `small` is empirically verified for `ai-tools:Summarize` v2 as of 2026-05; the others follow Make UI conventions but should be confirmed via the Module dropdown. The dropdown labels surface as e.g. "SmallModel: gpt-5-nano. Reasoning: minimal." — match those slugs. Do not use provider-specific model IDs (e.g., `"gpt-4o-mini"`) with the Make AI Provider — they are not valid tier names and will fail. The `RpcGetModels` RPC currently fails through the MCP server (org-context bug), so the model list cannot be queried programmatically — inspect the UI dropdown if unsure. See [make-mcp-reference — Known MCP server bugs](../make-mcp-reference/SKILL.md#known-mcp-server-bugs) for the org-context bug.
 
 **No Make AI Provider connection?** If the user has no `ai-provider` connection and cannot create one, check `connections_list` for alternative AI provider connections (`openai-gpt-3`, `anthropic-claude`, `gemini-ai-*`) and use the corresponding app-specific module instead of `ai-tools:Ask`. These modules accept provider-specific model IDs. See [Blueprint Construction — AI Tools](./blueprint-construction.md) for details.
 

--- a/skills/make-scenario-building/quick-patterns.md
+++ b/skills/make-scenario-building/quick-patterns.md
@@ -130,7 +130,7 @@ mapper: {
 
 **Gotchas:**
 - Column references use `{{1.\`0\`}}` — 0-based, backtick-quoted. NOT `{{1.1}}` or `{{1.jan}}`.
-- `model: "medium"` for Make AI Provider — `RpcGetModels` fails via MCP; use tier names directly.
+- `model: "small"` for Make AI Provider (cost-effective tier; valid slugs: `small`/`medium`/`large`). Older docs say `low/medium/high` — stale. `RpcGetModels` fails via MCP, so the dropdown can't be queried from the agent side — confirm the slug via Make UI if unsure.
 - `valueInputOption: "USER_ENTERED"` in updateRow mapper — mandatory for correct value formatting.
 - Columns without headers get `"undefined"` as their key in the `values` object.
 

--- a/skills/make-scenario-building/templates-lookup.md
+++ b/skills/make-scenario-building/templates-lookup.md
@@ -67,21 +67,6 @@ For long debug sessions, save the chosen blueprint to `/tmp` as JSON with key ta
 
 Include the original blueprint, plus a short `_keyTakeaways` array calling out the patterns to copy and the patterns to swap. Re-read this file later in the session instead of re-querying the MCP — `public-templates_get-blueprint` is rate-affecting and intermittently fails (see workarounds below).
 
-## Workarounds for "Organization-bound" Errors
-
-`public-templates_get` and `public-templates_get-blueprint` sometimes fail with:
-
-```
-MakeError: Organization-bound request can't be used outside of the Organization Context.
-```
-
-The `public-templates_list` call is NOT affected — only the per-template `get*` variants. Workaround order:
-
-1. **Retry once** — sometimes the next call succeeds without intervention.
-2. **Reauth the Make MCP server** — `/mcp` reauth in Claude Code, then retry. Often resolves the issue.
-3. **Fall back without the template** — proceed using `SKILL.md` + `make-module-configuring` skill alone. The template is a nice-to-have reference, not a requirement.
-
-See [make-mcp-reference — Known MCP server bugs](../make-mcp-reference/SKILL.md#known-mcp-server-bugs) for the full bug context and other affected endpoints.
 
 ## Official Documentation
 

--- a/skills/make-scenario-building/templates-lookup.md
+++ b/skills/make-scenario-building/templates-lookup.md
@@ -1,0 +1,90 @@
+---
+name: templates-lookup
+description: How to find public Make templates that match a planned scenario, then study their blueprints as canonical references for module versions, mapper shapes, parameter conventions, and source-module bindings (especially aggregator feeders).
+---
+
+# Templates Lookup
+
+## What It Does
+
+Searches Make's public template library for scenarios similar to the one being designed, fetches the closest match's full blueprint, and uses it as a structural reference. Templates surface canonical module versions, mapper shapes, and aggregator/feeder bindings that aren't visible from `app-module_get` alone — and they save the agent from guessing parameter shapes that the live API will reject at runtime.
+
+## When to Use
+
+**Recommended whenever the planned flow includes:**
+
+- An aggregator (`util:TextAggregator`, `builtin:BasicAggregator`, `util:FunctionAggregator2`, `util:AggregateAggregator`)
+- A Make AI Tools module or any AI provider module
+- An app the agent has not configured earlier in the session
+- Multi-module composition (more than 2-3 modules, branching, iteration)
+
+**Skip allowed for** single-module trigger → single-action flows with well-known apps and no aggregation/AI (e.g., webhook → Slack message, HTTP request → Google Sheets row).
+
+## How to Look Up
+
+Mirrors the chain format of `quick-patterns.md`:
+
+```
+1. public-templates_list      → Search by name + usedApps (apps from Phase 1 Step 2)
+2. (pick best match)          → Highest `usage` with most `usedApps` overlap
+3. public-templates_get-blueprint → Fetch the full blueprint
+4. (parse the blueprint)      → Extract canonical patterns (see "What to extract")
+```
+
+**Step 1 — search:** Pass `name` (use-case keywords, not the literal user prompt) AND `usedApps` (slug list from Step 2). Example: `name: "summarize emails", usedApps: ["google-email", "slack"]` returned template 14916 ("Summarize emails with Gmail and Make AI Tools then send it on Slack").
+
+If the first call returns empty, broaden — drop one app from `usedApps`, or try a synonym (`digest`, `daily summary`, `notify`). Don't filter `usedApps` too aggressively; templates often include builtins (`builtin`, `util`) that won't appear in your Phase 1 list.
+
+**Step 4 — what to extract from the blueprint:**
+
+| Pattern | Where to look |
+|---|---|
+| Per-module `version` (often differs from app version) | `flow[].version` |
+| Required parameter shapes | `flow[].parameters` |
+| Mapper field names + IML expression style | `flow[].mapper` |
+| Aggregator source binding | `flow[].parameters.feeder: <id>` |
+| Connection account types | `flow[].metadata.parameters[].type` (e.g. `account:google-restricted` vs `account:google-email`) |
+| Slack channel-selection chain | `channelWType` → `channelType` → `idType` → `channel` (one resolves to the next) |
+| Default/optional flags | `flow[].mapper.parse`, `mrkdwn`, `link_names`, etc. |
+
+## Mapping Template Patterns to User Requirements
+
+A template's pattern often differs from the user's exact ask. Common divergences:
+
+- **Per-item loop vs aggregated digest** — most "summarize" templates iterate one-summary-per-item; users frequently want a single combined digest. Adapt by inserting a Text Aggregator between source and AI module.
+- **Polling trigger vs scheduled action** — templates often start with `Watch X` polling triggers; users wanting daily fixed-time runs need a search action + scenario-level scheduling.
+- **Per-message vs single-message Slack output** — templates loop and send N messages; users may want one consolidated message.
+
+**Rule:** Use the template as a STRUCTURAL reference (module versions, parameter shapes, connection types), not as the literal blueprint to copy. Surface the diffs to the user during Phase 1 Step 3 confirmation so they can confirm the adaptation before deployment.
+
+## Persisting Blueprints Across the Session
+
+For long debug sessions, save the chosen blueprint to `/tmp` as JSON with key takeaways:
+
+```
+/tmp/make-template-<id>-reference.json
+```
+
+Include the original blueprint, plus a short `_keyTakeaways` array calling out the patterns to copy and the patterns to swap. Re-read this file later in the session instead of re-querying the MCP — `public-templates_get-blueprint` is rate-affecting and intermittently fails (see workarounds below).
+
+## Workarounds for "Organization-bound" Errors
+
+`public-templates_get` and `public-templates_get-blueprint` sometimes fail with:
+
+```
+MakeError: Organization-bound request can't be used outside of the Organization Context.
+```
+
+The `public-templates_list` call is NOT affected — only the per-template `get*` variants. Workaround order:
+
+1. **Retry once** — sometimes the next call succeeds without intervention.
+2. **Reauth the Make MCP server** — `/mcp` reauth in Claude Code, then retry. Often resolves the issue.
+3. **Fall back without the template** — proceed using `SKILL.md` + `make-module-configuring` skill alone. The template is a nice-to-have reference, not a requirement.
+
+See [make-mcp-reference — Known MCP server bugs](../make-mcp-reference/SKILL.md#known-mcp-server-bugs) for the full bug context and other affected endpoints.
+
+## Official Documentation
+
+- [Make Templates](https://www.make.com/en/templates)
+
+See also: [SKILL.md](./SKILL.md) Phase 1 Step 2.5, [Quick Patterns](./quick-patterns.md), [make-module-configuring/aggregators](../make-module-configuring/aggregators.md) for `parameters.feeder` details.


### PR DESCRIPTION
This PR expands the scenario-building documentation with a new “Templates Lookup” guide and adds/updates troubleshooting notes for known Make MCP server quirks (template blueprint fetch + org-context/RPC issues), plus related guidance for aggregators and AI Tools configuration.