### PR TITLE
feat: update documentation on field omission for updates and upserts

### DIFF
--- a/skills/make-module-configuring/SKILL.md
+++ b/skills/make-module-configuring/SKILL.md
@@ -46,6 +46,8 @@ These apply to every module configuration. Violating any of them is the most com
 
 5. **Connection selection is interactive.** Always present all matching connections to the user and let them choose. Never auto-select, even if only one match exists. See [Connections](./connections.md).
 
+6. **Omit unwritten fields on updates.** On update, upsert, and patch modules, omit any field that should be left alone from the `mapper` — never include it with an empty string `""`. An empty-string mapping overwrites the target record's existing value, looks identical to "unmapped" in the visual editor, and is not caught by `validate_module_configuration`. See [Mapping → Field Omission on Updates and Upserts](./mapping.md#field-omission-on-updates-and-upserts).
+
 ## Official Documentation
 
 - [Module Settings](https://help.make.com/module-settings)

--- a/skills/make-module-configuring/general-principles.md
+++ b/skills/make-module-configuring/general-principles.md
@@ -178,7 +178,7 @@ Many modules have nested parameter structures:
 - **Always use instructions format.** Calling `app-module_get` without requesting the instructions format gives less useful output. The instructions format includes component requirements and RPC instructions.
 - **Do not guess parameter names or values.** Parameter names are exact slugs, not human-readable labels. Always retrieve the interface first.
 - **Select parameters are strict.** Passing a value not in the allowed set causes a validation error. Check the spec for allowed values.
-- **Empty vs null vs missing.** Some modules treat these differently. An empty string `""` is not the same as omitting a parameter. When in doubt, omit optional parameters rather than sending empty values.
+- **Empty vs null vs missing.** Some modules treat these differently. An empty string `""` is not the same as omitting a parameter. When in doubt, omit optional parameters rather than sending empty values. The same rule applies — even more dangerously — to mapper fields on update and upsert modules, where an empty-string mapping silently overwrites existing record data. See [Mapping → Field Omission on Updates and Upserts](./mapping.md#field-omission-on-updates-and-upserts).
 - **Dynamic/conditional parameters.** Some modules have parameters that change based on other parameter values (e.g., selecting an action type reveals action-specific fields). The module interface describes these dependencies — set the controlling parameter first.
 - **Module version matters.** Different app versions may have different parameter sets. Always use the version from `app-modules_list`.
 - **Never omit RPC data parameter.** Even if only the connection ID is needed, always pass it. Omitting causes schema validation errors.

--- a/skills/make-module-configuring/mapping.md
+++ b/skills/make-module-configuring/mapping.md
@@ -112,7 +112,7 @@ Why this matters:
 }
 ```
 
-When the intent really is to clear a field, prefer the explicit IML `erase` function over `""` (see [IML Expressions](./iml-expressions.md)). It documents the intent in the blueprint and won't be confused for an accidental blank.
+When the intent really is to clear a field, prefer the explicit IML `erase` keyword over `""` (see [IML Expressions](./iml-expressions.md) — `erase` is listed there alongside `null` and `ignore`). It documents the intent in the blueprint and won't be confused for an accidental blank.
 
 Create modules are usually safe — most APIs treat `""` and "absent" as equivalent on insert — but the omission habit is worth keeping uniform across both, since the same blueprint shape often gets edited later into an update.
 

--- a/skills/make-module-configuring/mapping.md
+++ b/skills/make-module-configuring/mapping.md
@@ -81,6 +81,41 @@ The mapper is a JSON object where keys are the target module's input field names
 
 See [IML Expressions](./iml-expressions.md) for the full expression language.
 
+## Field Omission on Updates and Upserts
+
+On update, upsert, and patch modules — anything that modifies an existing record rather than creating one — **omit the key entirely from `mapper` for any field you don't intend to write**. Do not include the key with an empty string `""`.
+
+Why this matters:
+
+- An empty-string mapping writes `""` to the target field, overwriting whatever value was there. A missing key tells Make "leave this field alone."
+- Make's visual editor renders an empty-string mapping **identically** to a field with no mapping at all — both look like a blank input box. A user reviewing the scenario in the UI has no way to see that the mapper is silently zeroing out a field.
+- `validate_module_configuration` accepts `""` as a valid value, so the validator will not flag this. The damage only shows up at runtime, on real records.
+
+**Wrong** — sending an empty string for `phone` on an update will erase the contact's phone number:
+
+```json
+{
+  "recordId": "{{1.id}}",
+  "name": "{{1.firstName}} {{1.lastName}}",
+  "email": "{{1.email}}",
+  "phone": ""
+}
+```
+
+**Right** — omit `phone` entirely; the record's existing phone stays untouched:
+
+```json
+{
+  "recordId": "{{1.id}}",
+  "name": "{{1.firstName}} {{1.lastName}}",
+  "email": "{{1.email}}"
+}
+```
+
+When the intent really is to clear a field, prefer the explicit IML `erase` function over `""` (see [IML Expressions](./iml-expressions.md)). It documents the intent in the blueprint and won't be confused for an accidental blank.
+
+Create modules are usually safe — most APIs treat `""` and "absent" as equivalent on insert — but the omission habit is worth keeping uniform across both, since the same blueprint shape often gets edited later into an update.
+
 ## Gotchas
 
 - **Module IDs must be unique.** When generating blueprints, never assign the same ID to two modules. When editing existing blueprints, preserve existing IDs.

--- a/skills/make-scenario-building/mapping.md
+++ b/skills/make-scenario-building/mapping.md
@@ -82,6 +82,7 @@ Shopify - Watch Orders
 - **Array fields need iteration.** If you map an array field directly into a non-array input, you'll get the entire array as a single value. Use an Iterator to process items individually.
 - **Type coercion.** Make auto-coerces types in some cases (number to string, etc.), but explicit conversion with `toString()` or `toNumber()` is safer.
 - **Empty values.** Use `ifempty(value, fallback)` to provide defaults when a mapped field might be null/empty.
+- **Don't write empty strings into update mappers.** On any update, upsert, or patch module, omit fields you don't intend to write — including a key with `""` will silently overwrite the existing record value and look identical to "unmapped" in the visual editor. See [make-module-configuring → Field Omission on Updates and Upserts](../make-module-configuring/mapping.md#field-omission-on-updates-and-upserts).
 - **Source module identification.** In the Make UI, hovering over a mapped item causes the source module to pulse, making it easy to trace data origins.
 
 ## Official Documentation

--- a/skills/make-scenario-building/mapping.md
+++ b/skills/make-scenario-building/mapping.md
@@ -82,7 +82,7 @@ Shopify - Watch Orders
 - **Array fields need iteration.** If you map an array field directly into a non-array input, you'll get the entire array as a single value. Use an Iterator to process items individually.
 - **Type coercion.** Make auto-coerces types in some cases (number to string, etc.), but explicit conversion with `toString()` or `toNumber()` is safer.
 - **Empty values.** Use `ifempty(value, fallback)` to provide defaults when a mapped field might be null/empty.
-- **Don't write empty strings into update mappers.** On any update, upsert, or patch module, omit fields you don't intend to write — including a key with `""` will silently overwrite the existing record value and look identical to "unmapped" in the visual editor. See [make-module-configuring → Field Omission on Updates and Upserts](../make-module-configuring/mapping.md#field-omission-on-updates-and-upserts).
+- **Don't write empty strings into update mappers.** On any update, upsert, or patch module, omit fields you don't intend to write — including a field with an empty-string value (`""`) will silently overwrite the existing record value and look identical to "unmapped" in the visual editor. See [make-module-configuring → Field Omission on Updates and Upserts](../make-module-configuring/mapping.md#field-omission-on-updates-and-upserts).
 - **Source module identification.** In the Make UI, hovering over a mapped item causes the source module to pulse, making it easy to trace data origins.
 
 ## Official Documentation


### PR DESCRIPTION
This PR strengthens the Make skills documentation by explicitly warning that update/upsert/patch modules must omit mapper fields that should remain unchanged, because mapping an empty string can silently overwrite existing record data.