### PR TITLE
docs(iml): add explicit examples for logical operators

### DIFF
--- a/skills/make-module-configuring/iml-expressions.md
+++ b/skills/make-module-configuring/iml-expressions.md
@@ -73,6 +73,20 @@ IML uses **semicolons** (`;`) to separate function arguments, not commas:
 | `/` | Division |
 | `%` | Modulo |
 
+#### Logical operator usage
+
+Use the symbols `&` (AND) and `|` (OR) — never the words `AND` / `OR`, which are not valid IML and will fail to parse.
+
+**Example 1** — combining bundle fields:
+
+- Correct: `{{1.something & 2.somethingElse | 3.aaa}}`
+- Wrong: `{{1.something AND 2.somethingElse OR 3.aaa}}`
+
+**Example 2** — inside a conditional:
+
+- Correct: `{{if(1.status = "active" & 1.role = "admin"; "activeAdmin"; "someoneElse")}}`
+- Wrong: `{{if(1.status = "active" AND 1.role = "admin"; "activeAdmin"; "someoneElse")}}`
+
 ## Functions Reference
 
 **Only use functions documented here.** Never use a function, variable, operator, or keyword not listed in this reference.


### PR DESCRIPTION
## Summary

- Adds a **Logical operator usage** subsection directly under the Operators table in `skills/make-module-configuring/iml-expressions.md`.
- Shows two correct/wrong example pairs explicitly contrasting the IML symbols `&` / `|` with the invalid `AND` / `OR` keywords.

## Why

LLMs (and humans coming from SQL/JS) regularly hallucinate `AND` / `OR` keywords when generating IML expressions, producing invalid output like `{{1.something AND 2.somethingElse OR 3.aaa}}`. The operators table listed the symbols but did not show usage, so the wrong form was never explicitly ruled out. Making the contrast visible next to the symbols reduces hallucinations in scenario-building skills that depend on this reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)