### PR TITLE
fix(examples): use mocked id values

### DIFF
--- a/skills/make-api-shell-connection-workflow/http-fallback-shells.md
+++ b/skills/make-api-shell-connection-workflow/http-fallback-shells.md
@@ -158,7 +158,7 @@ for the full flow (StartSubscenario -> http:MakeRequest -> ReturnData). The
 middle module for the keychain variants differs only in `parameters`, e.g.:
 
 ```json
-{"tlsType": "", "proxyKeychain": "", "authenticationType": "apiKey", "apiKeyKeychain": 182303}
+{"tlsType": "", "proxyKeychain": "", "authenticationType": "apiKey", "apiKeyKeychain": 1}
 ```
 
 Creation rules that differ from app API-call shells:

--- a/skills/make-module-configuring/ai-agents.md
+++ b/skills/make-module-configuring/ai-agents.md
@@ -38,13 +38,13 @@ The agent module uses `makeConnectionId` in **parameters** (not `__IMTCONN__`). 
 
 ```json
 "parameters": {
-    "makeConnectionId": 14613
+    "makeConnectionId": 1
 },
 "metadata": {
     "restore": {
         "parameters": {
             "makeConnectionId": {
-                "label": "Maiak Token",
+                "label": "OpenAI Token",
                 "data": {
                     "scoped": "true",
                     "connection": "openai-gpt-3"
@@ -147,13 +147,13 @@ Tool modules that need connections use `__IMTCONN__` in `parameters` (same as no
     "id": 4,
     "module": "discord:createMessage",
     "parameters": {
-        "__IMTCONN__": 11867
+        "__IMTCONN__": 1
     },
     "metadata": {
         "restore": {
             "parameters": {
                 "__IMTCONN__": {
-                    "label": "DomiZ's Discord (Make (team1278341651986911253))",
+                    "label": "My Discord (Make (team123456789012345678))",
                     "data": {
                         "scoped": "true",
                         "connection": "discord"

--- a/skills/make-module-configuring/examples/ai-agent-full-blueprint.json
+++ b/skills/make-module-configuring/examples/ai-agent-full-blueprint.json
@@ -45,7 +45,7 @@
 			"module": "ai-local-agent:RunLocalAIAgent",
 			"version": 0,
 			"parameters": {
-				"makeConnectionId": 14613
+				"makeConnectionId": 1
 			},
 			"mapper": {
 				"defaultModel": "gpt-5.4",
@@ -68,7 +68,7 @@
 				"restore": {
 					"parameters": {
 						"makeConnectionId": {
-							"label": "Maiak Token",
+							"label": "OpenAI Token",
 							"data": {
 								"scoped": "true",
 								"connection": "openai-gpt-3"
@@ -248,13 +248,13 @@
 							"module": "discord:createMessage",
 							"version": 2,
 							"parameters": {
-								"__IMTCONN__": 11867
+								"__IMTCONN__": 1
 							},
 							"mapper": {
 								"select": "channel",
 								"content": "{{2.content}}",
 								"message_reference": {},
-								"channelId": "1224642245806788641"
+								"channelId": "234567890123456789"
 							},
 							"metadata": {
 								"designer": {
@@ -264,7 +264,7 @@
 								"restore": {
 									"parameters": {
 										"__IMTCONN__": {
-											"label": "DomiZ's Discord (Make (team1278341651986911253))",
+											"label": "My Discord (Make (team123456789012345678))",
 											"data": {
 												"scoped": "true",
 												"connection": "discord"


### PR DESCRIPTION
Example docs/JSON for the AI agent module and the HTTP fallback shell workflow carried leftover personal/bootstrap data -- instead, we're including mocked identifiers to keep the code clean of these.